### PR TITLE
Check if a folder is being compressed to a non-archive format

### DIFF
--- a/src/archive/zip.rs
+++ b/src/archive/zip.rs
@@ -11,7 +11,7 @@ use zip::{self, read::ZipFile, ZipArchive};
 
 use crate::{
     info, oof,
-    utils::{self, Bytes},
+    utils::{self, dir_is_empty, Bytes},
 };
 
 use self::utf8::get_invalid_utf8_paths;
@@ -93,7 +93,7 @@ where
             info!("Compressing '{}'.", utils::to_utf(path));
 
             if path.is_dir() {
-                if dir_is_empty(path)? {
+                if dir_is_empty(path) {
                     writer.add_directory(path.to_str().unwrap().to_owned(), options)?;
                 }
                 // If a dir has files, the files are responsible for creating them.
@@ -117,10 +117,6 @@ fn check_for_comments(file: &ZipFile) {
     if !comment.is_empty() {
         info!("Found comment in {}: {}", file.name(), comment);
     }
-}
-
-fn dir_is_empty(dir_path: &Path) -> crate::Result<bool> {
-    Ok(dir_path.read_dir()?.next().is_none())
 }
 
 #[cfg(unix)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,7 +35,7 @@ pub enum Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct FinalError {
     title: String,
     details: Vec<String>,
@@ -153,9 +153,12 @@ impl fmt::Display for Error {
             Error::CompressionTypo => FinalError::with_title("Possible typo detected")
                 .hint(format!("Did you mean '{}ouch compress{}'?", magenta(), reset()))
                 .into_owned(),
-            _err => {
-                todo!();
-            }
+            Error::UnknownExtensionError(_) => todo!(),
+            Error::AlreadyExists => todo!(),
+            Error::InvalidZipArchive(_) => todo!(),
+            Error::PermissionDenied => todo!(),
+            Error::UnsupportedZipArchive(_) => todo!(),
+            Error::Custom { reason } => reason.clone(),
         };
 
         write!(f, "{}", err)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,11 +1,18 @@
 use std::{
     cmp, env,
     ffi::OsStr,
-    fs,
+    fs::{self, ReadDir},
     path::{Path, PathBuf},
 };
 
 use crate::{dialogs::Confirmation, info, oof};
+
+/// Checks if the given path represents an empty directory.
+pub fn dir_is_empty(dir_path: &Path) -> bool {
+    let is_empty = |mut rd: ReadDir| rd.next().is_none();
+
+    dir_path.read_dir().ok().map(is_empty).unwrap_or_default()
+}
 
 pub fn create_dir_if_non_existent(path: &Path) -> crate::Result<()> {
     if !path.exists() {


### PR DESCRIPTION
Closes #78

The previous check already worked well when more than a path was supplied to a non-archive method. However, passing a single directory trips this check and results into a panic. This PR aims to solve that.