### PR TITLE
Apply clippy lints and small refactors

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -29,7 +29,7 @@ const BUFFER_CAPACITY: usize = 1024 * 64;
 
 fn represents_several_files(files: &[PathBuf]) -> bool {
     let is_non_empty_dir = |path: &PathBuf| {
-        let is_non_empty = || !dir_is_empty(&path);
+        let is_non_empty = || !dir_is_empty(path);
 
         path.is_dir().then(is_non_empty).unwrap_or_default()
     };
@@ -51,7 +51,7 @@ pub fn run(command: Command, flags: &oof::Flags) -> crate::Result<()> {
                     .hint("Examples:")
                     .hint(format!("  ouch compress ... {}.tar.gz", to_utf(&output_path)))
                     .hint(format!("  ouch compress ... {}.zip", to_utf(&output_path)))
-                    .into_owned();
+                    .clone();
 
                 return Err(Error::with_reason(reason));
             }
@@ -80,7 +80,7 @@ pub fn run(command: Command, flags: &oof::Flags) -> crate::Result<()> {
                     .hint(format!("Try inserting '.tar' or '.zip' before '{}'.", &formats[0]))
                     .hint(format!("From: {}", output_path))
                     .hint(format!(" To : {}", suggested_output_path))
-                    .into_owned();
+                    .clone();
 
                 return Err(Error::with_reason(reason));
             }
@@ -91,7 +91,7 @@ pub fn run(command: Command, flags: &oof::Flags) -> crate::Result<()> {
                     .detail(format!("{} can only be used at the start of the file extension.", format))
                     .hint(format!("If you wish to compress multiple files, start the extension with {}.", format))
                     .hint(format!("Otherwise, remove {} from '{}'.", format, to_utf(&output_path)))
-                    .into_owned();
+                    .clone();
 
                 return Err(Error::with_reason(reason));
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -79,10 +79,6 @@ impl FinalError {
         self.hints.push(hint.to_string());
         self
     }
-
-    pub fn into_owned(&mut self) -> Self {
-        std::mem::take(self)
-    }
 }
 
 impl fmt::Display for Error {
@@ -93,7 +89,7 @@ impl fmt::Display for Error {
                     .detail("Ouch could not detect the compression format")
                     .hint("Use a supported format extension, like '.zip' or '.tar.gz'")
                     .hint("Check https://github.com/vrmiguel/ouch for a full list of supported formats")
-                    .into_owned();
+                    .clone();
 
                 error
             }
@@ -111,7 +107,7 @@ impl fmt::Display for Error {
                 let error = FinalError::with_title("It seems you're trying to compress the root folder.")
                     .detail("This is unadvisable since ouch does compressions in-memory.")
                     .hint("Use a more appropriate tool for this, such as rsync.")
-                    .into_owned();
+                    .clone();
 
                 error
             }
@@ -123,7 +119,7 @@ impl fmt::Display for Error {
                     .hint("  - The output argument.")
                     .hint("")
                     .hint("Example: `ouch compress image.png img.zip`")
-                    .into_owned();
+                    .clone();
 
                 error
             }
@@ -134,7 +130,7 @@ impl fmt::Display for Error {
                     .hint("  - At least one input argument.")
                     .hint("")
                     .hint("Example: `ouch decompress imgs.tar.gz`")
-                    .into_owned();
+                    .clone();
 
                 error
             }
@@ -144,7 +140,7 @@ impl fmt::Display for Error {
                     .detail("It's probably our fault")
                     .detail("Please help us improve by reporting the issue at:")
                     .detail(format!("    {}https://github.com/vrmiguel/ouch/issues ", cyan()))
-                    .into_owned();
+                    .clone();
 
                 error
             }
@@ -152,7 +148,7 @@ impl fmt::Display for Error {
             Error::IoError { reason } => FinalError::with_title(reason),
             Error::CompressionTypo => FinalError::with_title("Possible typo detected")
                 .hint(format!("Did you mean '{}ouch compress{}'?", magenta(), reset()))
-                .into_owned(),
+                .clone(),
             Error::UnknownExtensionError(_) => todo!(),
             Error::AlreadyExists => todo!(),
             Error::InvalidZipArchive(_) => todo!(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ use lazy_static::lazy_static;
 /// The status code ouch has when an error is encountered
 pub const EXIT_FAILURE: i32 = libc::EXIT_FAILURE;
 
-const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 lazy_static! {
     static ref NO_COLOR_IS_SET: bool = {


### PR DESCRIPTION
Applied clippy (nightly) lints
Removed `FinalError::into_owned` and replaced with `clone`