### PR TITLE
Create CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+Thanks for your interest in contributing to `ouch`!
+
+Feel free to open an issue anytime you wish to ask a question, suggest a feature, report a bug, etc.
+
+# Requirements
+
+1. Be kind, considerate and respectfull.
+2. If editing .rs files, run `rustfmt` on them before commiting.
+
+Note that we are using `unstable` features of `rustfmt`, so you will need to change your toolchain to nightly.
+
+# Suggestions
+
+1. Ask for some guidance before solving an error if you feel like it.
+2. If editing Rust code, run `clippy` before commiting.


### PR DESCRIPTION
Starting with a pretty basic sketch.

Motivation:

Since #97, we now use `rustfmt` _unstable features_ again, those require _nightly_, so this need to be explained in `CONTRIBUTING.md`.