### PR TITLE
Add support for short tar archive extensions

### DIFF
--- a/src/extension.rs
+++ b/src/extension.rs
@@ -7,13 +7,16 @@ use self::CompressionFormat::*;
 #[derive(Clone, PartialEq, Eq, Debug)]
 /// Accepted extensions for input and output
 pub enum CompressionFormat {
-    Gzip, // .gz
-    Bzip, // .bz
-    Lzma, // .lzma
-    Tar,  // .tar (technically not a compression extension, but will do for now)
-    Tgz,  // .tgz
-    Zstd, // .zst
-    Zip,  // .zip
+    Gzip,  // .gz
+    Bzip,  // .bz
+    Lzma,  // .lzma
+    Tar,   // .tar (technically not a compression extension, but will do for now)
+    Tgz,   // .tgz
+    Tbz,   // .tbz
+    Tlzma, // .tlzma
+    Tzst,  // .tzst
+    Zstd,  // .zst
+    Zip,   // .zip
 }
 
 impl fmt::Display for CompressionFormat {
@@ -28,6 +31,9 @@ impl fmt::Display for CompressionFormat {
                 Lzma => ".lz",
                 Tar => ".tar",
                 Tgz => ".tgz",
+                Tbz => ".tbz",
+                Tlzma => ".tlz",
+                Tzst => ".tzst",
                 Zip => ".zip",
             }
         )
@@ -50,6 +56,9 @@ pub fn separate_known_extensions_from_name(mut path: &Path) -> (&Path, Vec<Compr
         extensions.push(match extension {
             "tar" => Tar,
             "tgz" => Tgz,
+            "tbz" | "tbz2" => Tbz,
+            "txz" | "tlz" | "tlzma" => Tlzma,
+            "tzst" => Tzst,
             "zip" => Zip,
             "bz" | "bz2" => Bzip,
             "gz" => Gzip,

--- a/tests/compress_and_decompress.rs
+++ b/tests/compress_and_decompress.rs
@@ -27,13 +27,22 @@ fn sanity_check_through_mime() {
     let bytes = generate_random_file_content(&mut SmallRng::from_entropy());
     test_file.write_all(&bytes).expect("to successfully write bytes to the file");
 
-    let formats = ["tar", "zip", "tar.gz", "tgz", "tar.bz", "tar.bz2", "tar.lzma", "tar.xz", "tar.zst"];
+    let formats = [
+        "tar", "zip", "tar.gz", "tgz", "tbz", "tbz2", "txz", "tlz", "tlzma", "tzst", "tar.bz", "tar.bz2", "tar.lzma",
+        "tar.xz", "tar.zst",
+    ];
 
     let expected_mimes = [
         "application/x-tar",
         "application/zip",
         "application/gzip",
         "application/gzip",
+        "application/x-bzip2",
+        "application/x-bzip2",
+        "application/x-xz",
+        "application/x-xz",
+        "application/x-xz",
+        "application/zstd",
         "application/x-bzip2",
         "application/x-bzip2",
         "application/x-xz",
@@ -69,6 +78,12 @@ fn test_each_format() {
     test_compressing_and_decompressing_archive("tar.lzma");
     test_compressing_and_decompressing_archive("tar.zst");
     test_compressing_and_decompressing_archive("tgz");
+    test_compressing_and_decompressing_archive("tbz");
+    test_compressing_and_decompressing_archive("tbz2");
+    test_compressing_and_decompressing_archive("txz");
+    test_compressing_and_decompressing_archive("tlz");
+    test_compressing_and_decompressing_archive("tlzma");
+    test_compressing_and_decompressing_archive("tzst");
     test_compressing_and_decompressing_archive("zip");
     test_compressing_and_decompressing_archive("zip.gz");
     test_compressing_and_decompressing_archive("zip.bz");


### PR DESCRIPTION
Currently only `.tgz` as short form of `tar.gz` is supported but there are short versions for the other compression formats as well. This PR adds support for:

- `tar.bz` => `tbz`
- `tar.bz2` => `tbz2`
- `tar.xz` => `txz`
- `tar.lz` => `tlz`
- `tar.lzma` => `tlzma`
- `tar.zst` => `tzst`
﻿