### PR TITLE
Omit "./" at the start of the path

### DIFF
--- a/src/archive/zip.rs
+++ b/src/archive/zip.rs
@@ -3,7 +3,7 @@
 use std::{
     env, fs,
     io::{self, prelude::*},
-    path::Component::CurDir,
+    path::Component,
     path::{Path, PathBuf},
 };
 
@@ -48,7 +48,7 @@ where
                         fs::create_dir_all(&path)?;
                     }
                 }
-                let file_path = file_path.strip_prefix(CurDir).unwrap_or_else(|_| file_path.as_path());
+                let file_path = file_path.strip_prefix(Component::CurDir).unwrap_or_else(|_| file_path.as_path());
 
                 info!("{:?} extracted. ({})", file_path.display(), Bytes::new(file.size()));
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,7 @@ use std::{
     cmp, env,
     ffi::OsStr,
     fs::{self, ReadDir},
-    path::Component::CurDir,
+    path::Component,
     path::{Path, PathBuf},
 };
 
@@ -46,7 +46,7 @@ pub fn user_wants_to_overwrite(path: &Path, flags: &oof::Flags) -> crate::Result
         _ => {}
     }
 
-    let path = path.strip_prefix(CurDir).unwrap_or_else(|_| path);
+    let path = path.strip_prefix(Component::CurDir).unwrap_or_else(|_| path);
     Confirmation::new("Do you want to overwrite 'FILE'?", Some("FILE")).ask(Some(&to_utf(path)))
 }
 


### PR DESCRIPTION
Addresses 3rd of #67
> Maybe remove the periods, they are pointless here, syntax feels weird after single quotes: './file'. .

## Before

```
[INFO] "./README.md" extracted. (3.09 kB)
Do you want to overwrite './tests/foo.md'? [Y/n] Y
[INFO] "./tests/foo.md" extracted. (8.06 kB)
```

## After

```
[INFO] "README.md" extracted. (3.09 kB)
Do you want to overwrite 'tests/foo.md'? [Y/n] Y
[INFO] "tests/foo.md" extracted. (8.06 kB)
```
