### PR TITLE
change output flag to dir flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ ouch decompress a.zip b.tar.gz c.tar
 ouch d a.zip
 ```
 
-You can redirect the decompression results to another folder with the `-o/--output` flag.
+You can redirect the decompression results to another folder with the `-d/--dir` flag.
 
 ```sh
 # Decompress 'summer_vacation.zip' inside of new folder 'pictures'
-ouch decompress summer_vacation.zip -o pictures
+ouch decompress summer_vacation.zip -d pictures
 ```
 
 ### Compressing

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -124,7 +124,7 @@ pub fn parse_args_from(mut args: Vec<OsString>) -> crate::Result<ParsedArgs> {
             ParsedArgs { command, flags }
         }
         Some(&"d") | Some(&"decompress") => {
-            flags_info.push(arg_flag!('o', "output"));
+            flags_info.push(arg_flag!('d', "dir"));
 
             if let Some(first_arg) = args.first() {
                 if is_typo(first_arg) {
@@ -138,7 +138,7 @@ pub fn parse_args_from(mut args: Vec<OsString>) -> crate::Result<ParsedArgs> {
             let (files, flags) = oof::filter_flags(args, &flags_info)?;
             let files = files.into_iter().map(PathBuf::from).collect();
 
-            let output_folder = flags.arg("output").map(PathBuf::from);
+            let output_folder = flags.arg("dir").map(PathBuf::from);
 
             // TODO: ensure all files are decompressible
 
@@ -203,10 +203,10 @@ mod tests {
         assert_eq!(test_cli("--version").unwrap().flags, oof::Flags::default());
 
         assert_eq!(
-            test_cli("decompress foo --yes bar --output folder").unwrap().flags,
+            test_cli("decompress foo --yes bar --dir folder").unwrap().flags,
             oof::Flags {
                 boolean_flags: vec!["yes"].into_iter().collect(),
-                argument_flags: vec![("output", OsString::from("folder"))].into_iter().collect(),
+                argument_flags: vec![("dir", OsString::from("folder"))].into_iter().collect(),
             }
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ fn help_command() {
     {yellow}--version{reset}     Display version information.
 
 {cyan}SPECIFIC FLAGS:{reset}
-    {yellow}-o{reset}, {yellow}--output{reset} FOLDER_PATH    When decompressing, to decompress files to
+    {yellow}-d{reset}, {yellow}--dir{reset} FOLDER_PATH    When decompressing, to decompress files to
                                 another folder.
 
 Visit https://github.com/ouch-org/ouch for more usage examples.",


### PR DESCRIPTION
this changes the `-o/--output` to `-d/--dir` in decompress Command.

fixes #115 