### PR TITLE
Generate completions and man page

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,19 +104,26 @@ jobs:
       - name: Install dependencies for musl libc
         run: |
           sudo apt-get update
-          sudo apt-get install musl-tools
+          sudo apt-get install help2man musl-tools
 
       - name: Run cargo build
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --release --target x86_64-unknown-linux-musl
+        env:
+          GEN_COMPLETIONS: 1
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --target x86_64-unknown-linux-musl
+
+      - name: Build man page and find completions
+        run: |
+          help2man target/x86_64-unknown-linux-musl/release/ouch > ouch.1
+          cp -r target/x86_64-unknown-linux-musl/release/build/ouch-*/out/completions .
 
       - name: Strip binary
         run: strip target/x86_64-unknown-linux-musl/release/ouch
@@ -127,6 +134,17 @@ jobs:
           name: 'ouch-x86_64-linux-musl'
           path: target/x86_64-unknown-linux-musl/release/ouch
 
+      - name: Upload completions
+        uses: actions/upload-artifact@v2
+        with:
+          name: completions
+          path: completions
+
+      - name: Upload man page
+        uses: actions/upload-artifact@v2
+        with:
+          name: ouch.1
+          path: ouch.1
 
   x86_64_glibc:
     name: Ubuntu 20.04 (glibc)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_generate"
+version = "3.0.0-beta.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "097ab5db1c3417442270cd57c8dd39f6c3114d3ce09d595f9efddbb1fcfaa799"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +292,7 @@ dependencies = [
  "atty",
  "bzip2",
  "clap",
+ "clap_generate",
  "flate2",
  "infer",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,10 @@ zip         = { version =  "0.5.13", default-features = false, features = ["defl
 flate2      = { version = "1.0.22", default-features = false, features = ["zlib"] }
 zstd        = { version = "0.9.0", default-features = false, features = ["thin"] }
 
+[build-dependencies]
+clap = "=3.0.0-beta.5"
+clap_generate = "=3.0.0-beta.5"
+
 [dev-dependencies]
 tempfile = "3.2.0"
 infer = "0.5.0"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,22 @@
+use clap::{ArgEnum, IntoApp};
+use clap_generate::{generate_to, Shell};
+
+use std::{env, fs::create_dir_all, path::Path};
+
+include!("src/opts.rs");
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=GEN_COMPLETIONS");
+
+    if env::var_os("GEN_COMPLETIONS") != Some("1".into()) {
+        return;
+    }
+
+    let out = &Path::new(&env::var_os("OUT_DIR").unwrap()).join("completions");
+    create_dir_all(out).unwrap();
+    let app = &mut Opts::into_app();
+
+    for shell in Shell::value_variants() {
+        generate_to(*shell, app, "ouch", out).unwrap();
+    }
+}

--- a/src/archive/tar.rs
+++ b/src/archive/tar.rs
@@ -11,7 +11,8 @@ use walkdir::WalkDir;
 
 use crate::{
     info,
-    utils::{self, Bytes, QuestionPolicy},
+    utils::{self, Bytes},
+    QuestionPolicy,
 };
 
 pub fn unpack_archive(

--- a/src/archive/zip.rs
+++ b/src/archive/zip.rs
@@ -11,7 +11,7 @@ use zip::{self, read::ZipFile, ZipArchive};
 
 use crate::{
     info,
-    utils::{self, dir_is_empty,strip_cur_dir, Bytes},
+    utils::{self, dir_is_empty, strip_cur_dir, Bytes},
 };
 
 use self::utf8::get_invalid_utf8_paths;

--- a/src/archive/zip.rs
+++ b/src/archive/zip.rs
@@ -11,7 +11,8 @@ use zip::{self, read::ZipFile, ZipArchive};
 
 use crate::{
     info,
-    utils::{self, dir_is_empty, strip_cur_dir, Bytes, QuestionPolicy},
+    utils::{self, dir_is_empty, strip_cur_dir, Bytes},
+    QuestionPolicy,
 };
 
 use self::utf8::get_invalid_utf8_paths;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,8 +7,7 @@ use std::{
 
 use clap::Parser;
 
-pub use crate::utils::QuestionPolicy;
-use crate::{Error, Opts, Subcommand};
+use crate::{Error, Opts, QuestionPolicy, Subcommand};
 
 impl Opts {
     /// A helper method that calls `clap::Parser::parse` and then translates relative paths to absolute.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,50 +5,9 @@ use std::{
     vec::Vec,
 };
 
-use clap::{Parser, ValueHint};
+use clap::Parser;
 
-use crate::Error;
-
-#[derive(Parser, Debug)]
-#[clap(version, about)]
-pub struct Opts {
-    /// Skip overwrite questions positively.
-    #[clap(short, long, conflicts_with = "no")]
-    pub yes: bool,
-
-    /// Skip overwrite questions negatively.
-    #[clap(short, long)]
-    pub no: bool,
-
-    #[clap(subcommand)]
-    pub cmd: Subcommand,
-}
-
-#[derive(Parser, PartialEq, Eq, Debug)]
-pub enum Subcommand {
-    /// Compress files.    Alias: c
-    #[clap(alias = "c")]
-    Compress {
-        /// Files to be compressed
-        #[clap(required = true, min_values = 1)]
-        files: Vec<PathBuf>,
-
-        /// The resulting file. Its extensions specify how the files will be compressed and they need to be supported
-        #[clap(required = true, value_hint = ValueHint::FilePath)]
-        output: PathBuf,
-    },
-    /// Compress files.    Alias: d
-    #[clap(alias = "d")]
-    Decompress {
-        /// Files to be decompressed
-        #[clap(required = true, min_values = 1)]
-        files: Vec<PathBuf>,
-
-        /// Decompress files in a directory other than the current
-        #[clap(short, long, value_hint = ValueHint::DirPath)]
-        output: Option<PathBuf>,
-    },
-}
+use crate::{Error, Opts, Subcommand};
 
 impl Opts {
     /// A helper method that calls `clap::Parser::parse` and then translates relative paths to absolute.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -12,7 +12,6 @@ use utils::colors;
 
 use crate::{
     archive,
-    cli::{Opts, Subcommand},
     error::FinalError,
     extension::{
         self,
@@ -22,7 +21,7 @@ use crate::{
     utils::nice_directory_display,
     utils::to_utf,
     utils::{self, dir_is_empty},
-    Error,
+    Error, Opts, Subcommand,
 };
 
 // Used in BufReader and BufWriter to perform less syscalls

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -18,10 +18,8 @@ use crate::{
         CompressionFormat::{self, *},
     },
     info,
-    utils::nice_directory_display,
-    utils::to_utf,
-    utils::{self, dir_is_empty, QuestionPolicy},
-    Error, Opts, Subcommand,
+    utils::{self, dir_is_empty, nice_directory_display, to_utf},
+    Error, Opts, QuestionPolicy, Subcommand,
 };
 
 // Used in BufReader and BufWriter to perform less syscalls

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,18 +5,20 @@
 //! 2. It's required by some integration tests at tests/ folder.
 
 // Public modules
-pub mod cli;
+pub mod archive;
 pub mod commands;
 
 // Private modules
-pub mod archive;
+mod cli;
 mod dialogs;
 mod error;
 mod extension;
 mod macros;
+mod opts;
 mod utils;
 
 pub use error::{Error, Result};
+pub use opts::{Opts, Subcommand};
 
 /// The status code ouch has when an error is encountered
 pub const EXIT_FAILURE: i32 = libc::EXIT_FAILURE;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ mod utils;
 
 pub use error::{Error, Result};
 pub use opts::{Opts, Subcommand};
+pub use utils::QuestionPolicy;
 
 /// The status code ouch has when an error is encountered
 pub const EXIT_FAILURE: i32 = libc::EXIT_FAILURE;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use ouch::{cli::Opts, commands, Result};
+use ouch::{commands, Opts, Result};
 
 fn main() {
     if let Err(err) = run() {

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -1,0 +1,44 @@
+use clap::{Parser, ValueHint};
+
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+#[clap(version, about)]
+pub struct Opts {
+    /// Skip overwrite questions positively.
+    #[clap(short, long, conflicts_with = "no")]
+    pub yes: bool,
+
+    /// Skip overwrite questions negatively.
+    #[clap(short, long)]
+    pub no: bool,
+
+    #[clap(subcommand)]
+    pub cmd: Subcommand,
+}
+
+#[derive(Parser, PartialEq, Eq, Debug)]
+pub enum Subcommand {
+    /// Compress files.    Alias: c
+    #[clap(alias = "c")]
+    Compress {
+        /// Files to be compressed
+        #[clap(required = true, min_values = 1)]
+        files: Vec<PathBuf>,
+
+        /// The resulting file. Its extensions specify how the files will be compressed and they need to be supported
+        #[clap(required = true, value_hint = ValueHint::FilePath)]
+        output: PathBuf,
+    },
+    /// Compress files.    Alias: d
+    #[clap(alias = "d")]
+    Decompress {
+        /// Files to be decompressed
+        #[clap(required = true, min_values = 1)]
+        files: Vec<PathBuf>,
+
+        /// Decompress files in a directory other than the current
+        #[clap(short, long, value_hint = ValueHint::DirPath)]
+        output: Option<PathBuf>,
+    },
+}

--- a/tests/compress_and_decompress.rs
+++ b/tests/compress_and_decompress.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 
-use ouch::{cli::QuestionPolicy, commands::run, Opts, Subcommand};
+use ouch::{commands::run, Opts, QuestionPolicy, Subcommand};
 use rand::{rngs::SmallRng, RngCore, SeedableRng};
 use tempfile::NamedTempFile;
 use utils::*;

--- a/tests/compress_and_decompress.rs
+++ b/tests/compress_and_decompress.rs
@@ -7,10 +7,7 @@ use std::{
     time::Duration,
 };
 
-use ouch::{
-    cli::{Opts, Subcommand},
-    commands::run,
-};
+use ouch::{commands::run, Opts, Subcommand};
 use rand::{rngs::SmallRng, RngCore, SeedableRng};
 use tempfile::NamedTempFile;
 use utils::*;

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -7,7 +7,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use ouch::{cli::QuestionPolicy, commands::run, Opts, Subcommand};
+use ouch::{commands::run, Opts, QuestionPolicy, Subcommand};
 
 pub fn create_empty_dir(at: &Path, filename: &str) -> PathBuf {
     let dirname = Path::new(filename);

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -7,10 +7,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use ouch::{
-    cli::{Opts, Subcommand},
-    commands::run,
-};
+use ouch::{commands::run, Opts, Subcommand};
 
 pub fn create_empty_dir(at: &Path, filename: &str) -> PathBuf {
     let dirname = Path::new(filename);


### PR DESCRIPTION
Moved some parts of `cli.rs` to `opts.rs`, `ouch::cli::{Opts, QuestionPolicy, Subcommand}` are moved to `ouch::{Opts, QuestionPolicy, Subcommand}`

This uses a build script to generate completions when `GEN_COMPLETIONS=1` is present, this generates completions to `$OUT_DIR/completions`, for example:
- `GEN_COMPLETIONS=1 cargo build` would generate completions to `target/debug/build/ouch-*/out/completions`
- `GEN_COMPLETIONS=1 cargo build --release --target x86_64-unknown-linux-musl` would generate completions to `target/x86_64-unknown-linux-musl/release/build/ouch-*/out/completions`

A few more artifacts are generated in the completions in the `x86_64-musl` job:
- completions are generated and uploaded to `completions`
- man pages are generated with `help2man` and uploaded to `ouch.1`

Design choices:
- I chose completions to be generated to `OUT_DIR`, which is what rust/cargo recommends, but it also makes paths incredibly long and can possibly collide (when globbing with `*`) when completions are generated multiple times
- Man page could also be gzipped
- Completions could be in multiple artifacts, and powershell and zsh completions are named slightly intuitively since I left them as defaults

Side notes:
- I couldn't figure out a way for man pages to be generated inside `build.rs` since `help2man` excepts an executable, not a string
- The current ci is very big and repetitive, I have a very similar workflow that tests, builds, and creates releases on multiple platforms that we can probably borrow from: https://github.com/figsoda/mmtc/tree/main/.github/workflows