### PR TITLE
Check the format with Github Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -276,10 +276,8 @@ jobs:
       #     path: target\x86_64-pc-windows-gnu\release\ouch.exe
 
   fmt:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+    name: Check sourcecode format
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout sources
@@ -293,12 +291,6 @@ jobs:
           target: x86_64-unknown-linux-musl
           components: rustfmt
           override: true
-
-      - name: Run cargo build
-        uses: actions-rs/cargo@v1
-        if: ${{ matrix.os=='windows-latest' }}
-        with:
-          command: build
 
       - name: Check format with cargo fmt
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
As you can read at this review [1] a format checking is something good to
avoid branch conflitcs etc.

Use a job to check the format of the sourcecode with `cargo fmt`
command. The new step does not change any code, but returns an error
when `check` does not pass with 0 issues.

[1] https://github.com/ouch-org/ouch/pull/125#pullrequestreview-786299883
