### PR TITLE
Print number of unpacked files

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -338,6 +338,8 @@ fn decompress_file(
 
     utils::create_dir_if_non_existent(output_folder)?;
 
+    let files_unpacked;
+
     match formats[0] {
         Gzip | Bzip | Lzma | Zstd => {
             reader = chain_reader_decoder(&formats[0], reader)?;
@@ -346,25 +348,26 @@ fn decompress_file(
             let mut writer = fs::File::create(&output_path)?;
 
             io::copy(&mut reader, &mut writer)?;
+            files_unpacked = vec![output_path];
         }
         Tar => {
-            let _ = crate::archive::tar::unpack_archive(reader, output_folder, question_policy)?;
+            files_unpacked = crate::archive::tar::unpack_archive(reader, output_folder, question_policy)?;
         }
         Tgz => {
             let reader = chain_reader_decoder(&Gzip, reader)?;
-            let _ = crate::archive::tar::unpack_archive(reader, output_folder, question_policy)?;
+            files_unpacked = crate::archive::tar::unpack_archive(reader, output_folder, question_policy)?;
         }
         Tbz => {
             let reader = chain_reader_decoder(&Bzip, reader)?;
-            let _ = crate::archive::tar::unpack_archive(reader, output_folder, question_policy)?;
+            files_unpacked = crate::archive::tar::unpack_archive(reader, output_folder, question_policy)?;
         }
         Tlzma => {
             let reader = chain_reader_decoder(&Lzma, reader)?;
-            let _ = crate::archive::tar::unpack_archive(reader, output_folder, question_policy)?;
+            files_unpacked = crate::archive::tar::unpack_archive(reader, output_folder, question_policy)?;
         }
         Tzst => {
             let reader = chain_reader_decoder(&Zstd, reader)?;
-            let _ = crate::archive::tar::unpack_archive(reader, output_folder, question_policy)?;
+            files_unpacked = crate::archive::tar::unpack_archive(reader, output_folder, question_policy)?;
         }
         Zip => {
             eprintln!("Compressing first into .zip.");
@@ -378,11 +381,12 @@ fn decompress_file(
             io::copy(&mut reader, &mut vec)?;
             let zip_archive = zip::ZipArchive::new(io::Cursor::new(vec))?;
 
-            let _ = crate::archive::zip::unpack_archive(zip_archive, output_folder, question_policy)?;
+            files_unpacked = crate::archive::zip::unpack_archive(zip_archive, output_folder, question_policy)?;
         }
     }
 
     info!("Successfully decompressed archive in {}.", nice_directory_display(output_folder));
+    info!("Files unpacked: {}", files_unpacked.len());
 
     Ok(())
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -346,31 +346,25 @@ fn decompress_file(
             let mut writer = fs::File::create(&output_path)?;
 
             io::copy(&mut reader, &mut writer)?;
-            info!("Successfully decompressed archive in {}.", nice_directory_display(output_path));
         }
         Tar => {
             let _ = crate::archive::tar::unpack_archive(reader, output_folder, question_policy)?;
-            info!("Successfully decompressed archive in {}.", nice_directory_display(output_folder));
         }
         Tgz => {
             let reader = chain_reader_decoder(&Gzip, reader)?;
             let _ = crate::archive::tar::unpack_archive(reader, output_folder, question_policy)?;
-            info!("Successfully decompressed archive in {}.", nice_directory_display(output_folder));
         }
         Tbz => {
             let reader = chain_reader_decoder(&Bzip, reader)?;
             let _ = crate::archive::tar::unpack_archive(reader, output_folder, question_policy)?;
-            info!("Successfully decompressed archive in {}.", nice_directory_display(output_folder));
         }
         Tlzma => {
             let reader = chain_reader_decoder(&Lzma, reader)?;
             let _ = crate::archive::tar::unpack_archive(reader, output_folder, question_policy)?;
-            info!("Successfully decompressed archive in {}.", nice_directory_display(output_folder));
         }
         Tzst => {
             let reader = chain_reader_decoder(&Zstd, reader)?;
             let _ = crate::archive::tar::unpack_archive(reader, output_folder, question_policy)?;
-            info!("Successfully decompressed archive in {}.", nice_directory_display(output_folder));
         }
         Zip => {
             eprintln!("Compressing first into .zip.");
@@ -385,10 +379,10 @@ fn decompress_file(
             let zip_archive = zip::ZipArchive::new(io::Cursor::new(vec))?;
 
             let _ = crate::archive::zip::unpack_archive(zip_archive, output_folder, question_policy)?;
-
-            info!("Successfully decompressed archive in {}.", nice_directory_display(output_folder));
         }
     }
+
+    info!("Successfully decompressed archive in {}.", nice_directory_display(output_folder));
 
     Ok(())
 }


### PR DESCRIPTION
When you use the decompression tool you can avoid to overwrite one (or more) files. `crate::archive::tar::unpack_archive` already returns a list of the unpacked files, so after the "Success" information,﻿ it also prints the number of successfully unpacked files.
