### PR TITLE
Simplify cli canonicalize implementation

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -45,12 +45,13 @@ pub fn run(args: Opts, question_policy: QuestionPolicy) -> crate::Result<()> {
 
             if formats.is_empty() {
                 let error = FinalError::with_title(format!("Cannot compress to '{}'.", to_utf(&output_path)))
-                    .detail("You shall supply the compression format via the extension.")
-                    .hint("Try adding something like .tar.gz or .zip to the output file.")
+                    .detail("You shall supply the compression format")
+                    .hint("Try adding supported extensions (see --help):")
+                    .hint(format!("  ouch compress <FILES>... {}.tar.gz", to_utf(&output_path)))
+                    .hint(format!("  ouch compress <FILES>... {}.zip", to_utf(&output_path)))
                     .hint("")
-                    .hint("Examples:")
-                    .hint(format!("  ouch compress ... {}.tar.gz", to_utf(&output_path)))
-                    .hint(format!("  ouch compress ... {}.zip", to_utf(&output_path)));
+                    .hint("Alternatively, you can overwrite this option by using the '--format' flag:")
+                    .hint(format!("  ouch compress <FILES>... {} --format tar.gz", to_utf(&output_path)));
 
                 return Err(error.into());
             }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -79,7 +79,7 @@ pub fn run(args: Opts, question_policy: QuestionPolicy) -> crate::Result<()> {
                     .detail("The only supported formats that archive files into an archive are .tar and .zip.")
                     .hint(format!("Try inserting '.tar' or '.zip' before '{}'.", &formats[0]))
                     .hint(format!("From: {}", output_path))
-                    .hint(format!(" To : {}", suggested_output_path));
+                    .hint(format!("To:   {}", suggested_output_path));
 
                 return Err(error.into());
             }

--- a/src/dialogs.rs
+++ b/src/dialogs.rs
@@ -33,7 +33,7 @@ impl<'a> Confirmation<'a> {
     pub fn ask(&self, substitute: Option<&'a str>) -> crate::Result<bool> {
         let message = match (self.placeholder, substitute) {
             (None, _) => Cow::Borrowed(self.prompt),
-            (Some(_), None) => return Err(crate::Error::InternalError),
+            (Some(_), None) => unreachable!("dev error, should be reported, we checked this won't happen"),
             (Some(placeholder), Some(subs)) => Cow::Owned(self.prompt.replace(placeholder, subs)),
         };
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,8 +35,6 @@ pub enum Error {
     /// TO BE REMOVED
     UnsupportedZipArchive(&'static str),
     /// TO BE REMOVED
-    InternalError,
-    /// TO BE REMOVED
     CompressingRootFolder,
     /// TO BE REMOVED
     MissingArgumentsForCompression,
@@ -150,13 +148,6 @@ impl fmt::Display for Error {
                     .hint("  - At least one input argument.")
                     .hint("")
                     .hint("Example: `ouch decompress imgs.tar.gz`")
-            }
-            Error::InternalError => {
-                FinalError::with_title("InternalError :(")
-                    .detail("This should not have happened")
-                    .detail("It's probably our fault")
-                    .detail("Please help us improve by reporting the issue at:")
-                    .detail(format!("    {}https://github.com/ouch-org/ouch/issues ", *CYAN))
             }
             Error::IoError { reason } => FinalError::with_title(reason),
             Error::CompressionTypo => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -175,13 +175,6 @@ impl fmt::Display for Error {
     }
 }
 
-impl Error {
-    /// TO BE REMOVED
-    pub fn with_reason(reason: FinalError) -> Self {
-        Self::Custom { reason }
-    }
-}
-
 impl From<std::io::Error> for Error {
     fn from(err: std::io::Error) -> Self {
         match err.kind() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -72,6 +72,21 @@ pub fn to_utf(os_str: impl AsRef<OsStr>) -> String {
     text.trim_matches('"').to_string()
 }
 
+/// Converts a slice of AsRef<OsStr> to comma separated String
+///
+/// Panics if the slice is empty.
+pub fn concatenate_list_of_os_str(os_strs: &[impl AsRef<OsStr>]) -> String {
+    let mut iter = os_strs.iter().map(AsRef::as_ref);
+
+    let mut string = to_utf(iter.next().unwrap()); // May panic
+
+    for os_str in iter {
+        string += ", ";
+        string += &to_utf(os_str);
+    }
+    string
+}
+
 /// Display the directory name, but change to "current directory" when necessary.
 pub fn nice_directory_display(os_str: impl AsRef<OsStr>) -> String {
     let text = to_utf(os_str);


### PR DESCRIPTION
The FileNotFound error should be treated in the `crate::Error::From<io::Error>` conversion implementation. 