### PR TITLE
switch from lz4_flex to lzzzz, enable lz4 tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,15 +338,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
-name = "lz4_flex"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177c079243f6867429aca5af5053747f57e329d44f0c58bebca078cd14873ec2"
-dependencies = [
- "twox-hash",
-]
-
-[[package]]
 name = "lzma-sys"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,6 +346,15 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "lzzzz"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6d891cedd3b1659c206a60ff8afd15bccd7c2754b157f8a164861989e042b88"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -411,7 +411,7 @@ dependencies = [
  "infer",
  "libc",
  "linked-hash-map",
- "lz4_flex",
+ "lzzzz",
  "once_cell",
  "parse-display",
  "proptest",
@@ -676,12 +676,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,16 +794,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "twox-hash"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
-dependencies = [
- "cfg-if",
- "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ walkdir     = "2.3.2"
 bzip2       = "0.4.3"
 libc        = "0.2.103"
 tar         = "0.4.37"
-lz4_flex    = "0.9.0"
+lzzzz       = "0.8.0"
 xz2         = "0.1.6"
 zip         = { version =  "0.5.13", default-features = false, features = ["deflate-miniz"] }
 flate2      = { version = "1.0.22", default-features = false, features = ["zlib"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,8 @@ use crate::utils::colors::*;
 pub enum Error {
     /// Not every IoError, some of them get filtered by `From<io::Error>` into other variants
     IoError { reason: String },
+    /// From lzzzz::lz4f::Error
+    Lz4Error { reason: String },
     /// Detected from io::Error if .kind() is io::ErrorKind::NotFound
     NotFound { error_title: String },
     /// NEEDS MORE CONTEXT
@@ -97,6 +99,7 @@ impl fmt::Display for Error {
                     .hint("Use a more appropriate tool for this, such as rsync.")
             }
             Error::IoError { reason } => FinalError::with_title(reason),
+            Error::Lz4Error { reason } => FinalError::with_title(reason),
             Error::AlreadyExists { error_title } => FinalError::with_title(error_title).detail("File already exists"),
             Error::InvalidZipArchive(reason) => FinalError::with_title("Invalid zip archive").detail(reason),
             Error::PermissionDenied { error_title } => FinalError::with_title(error_title).detail("Permission denied"),
@@ -116,6 +119,12 @@ impl From<std::io::Error> for Error {
             std::io::ErrorKind::AlreadyExists => Self::AlreadyExists { error_title: err.to_string() },
             _other => Self::IoError { reason: err.to_string() },
         }
+    }
+}
+
+impl From<lzzzz::lz4f::Error> for Error {
+    fn from(err: lzzzz::lz4f::Error) -> Self {
+        Self::Lz4Error { reason: err.to_string() }
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -33,7 +33,7 @@ enum FileExtension {
     Bz,
     Bz2,
     Gz,
-    // Lz4, // broken
+    Lz4,
     Lz,
     Lzma,
     Xz,


### PR DESCRIPTION
lz4 tests was disabled in #163 because some compressions were broken
this switches from [lz4_flex](https://lib.rs/lz4_flex) crate to [lzzzz](https://lib.rs/lzzzz) which fixes the issue

[lz4](https://lib.rs/lz4) is more popular, but I ran into other issues