### PR TITLE
Truncate long messages in the progress bar

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -65,7 +65,7 @@ impl Progress {
                 let mut t = String::new();
                 t += "{wide_msg} [{elapsed_precise}] ";
                 if precise && current_position_fn.is_some() {
-                    t += "[{wide_bar:.cyan/blue}] ";
+                    t += "[{bar:.cyan/blue}] ";
                 } else {
                     t += "{spinner:.green} ";
                 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -63,7 +63,7 @@ impl Progress {
         thread::spawn(move || {
             let template = {
                 let mut t = String::new();
-                t += "{prefix} [{elapsed_precise}] ";
+                t += "{wide_msg} [{elapsed_precise}] ";
                 if precise && current_position_fn.is_some() {
                     t += "[{wide_bar:.cyan/blue}] ";
                 } else {
@@ -88,7 +88,7 @@ impl Progress {
                     pb.tick();
                 }
                 if let Ok(msg) = msg_rx.try_recv() {
-                    pb.set_prefix(msg);
+                    pb.set_message(msg);
                 }
                 thread::sleep(Duration::from_millis(100));
             }


### PR DESCRIPTION
Currently if the path is too long the progress bar wraps around, and starts spamming messages in new lines.

By using, `wide_msg`, long messages are automatically truncated by indicatf.