### PR TITLE
Fix zip memory warnings

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -347,14 +347,10 @@ fn compress_files(files: Vec<PathBuf>, formats: Vec<Extension>, output_file: fs:
             writer.flush()?;
         }
         Zip => {
-            eprintln!("{yellow}Warning:{reset}", yellow = *colors::YELLOW, reset = *colors::RESET);
-            eprintln!("\tCompressing .zip entirely in memory.");
-            eprintln!("\tIf the file is too big, your PC might freeze!");
-            eprintln!(
-                "\tThis is a limitation for formats like '{}'.",
-                formats.iter().map(|format| format.to_string()).collect::<String>()
-            );
-            eprintln!("\tThe design of .zip makes it impossible to compress via stream.");
+            eprintln!("{orange}[WARNING]{reset}", orange = *colors::ORANGE, reset = *colors::RESET);
+            eprintln!("\tThere is a limitation for .zip archives with extra extensions. (e.g. <file>.zip.gz)\
+            \n\tThe design of .zip makes it impossible to compress via stream, so it must be done entirely in memory.\
+            \n\tBy compressing .zip with extra compression formats, you can run out of RAM if the file is too large!");
 
             let mut vec_buffer = io::Cursor::new(vec![]);
 
@@ -505,12 +501,10 @@ fn decompress_file(
             };
         }
         Zip => {
-            eprintln!("Compressing first into .zip.");
-            eprintln!("Warning: .zip archives with extra extensions have a downside.");
-            eprintln!(
-                "The only way is loading everything into the RAM while compressing, and then write everything down."
-            );
-            eprintln!("this means that by compressing .zip with extra compression formats, you can run out of RAM if the file is too large!");
+            eprintln!("{orange}[WARNING]{reset}", orange = *colors::ORANGE, reset = *colors::RESET);
+            eprintln!("\tThere is a limitation for .zip archives with extra extensions. (e.g. <file>.zip.gz)\
+            \n\tThe design of .zip makes it impossible to compress via stream, so it must be done entirely in memory.\
+            \n\tBy compressing .zip with extra compression formats, you can run out of RAM if the file is too large!");
 
             let mut vec = vec![];
             io::copy(&mut reader, &mut vec)?;
@@ -593,10 +587,10 @@ fn list_archive_contents(
     let files = match formats[0] {
         Tar => crate::archive::tar::list_archive(reader)?,
         Zip => {
-            eprintln!("Listing files from zip archive.");
-            eprintln!("Warning: .zip archives with extra extensions have a downside.");
-            eprintln!("The only way is loading everything into the RAM while compressing, and then reading the archive contents.");
-            eprintln!("this means that by compressing .zip with extra compression formats, you can run out of RAM if the file is too large!");
+            eprintln!("{orange}[WARNING]{reset}", orange = *colors::ORANGE, reset = *colors::RESET);
+            eprintln!("\tThere is a limitation for .zip archives with extra extensions. (e.g. <file>.zip.gz)\
+            \n\tThe design of .zip makes it impossible to compress via stream, so it must be done entirely in memory.\
+            \n\tBy compressing .zip with extra compression formats, you can run out of RAM if the file is too large!");
 
             let mut vec = vec![];
             io::copy(&mut reader, &mut vec)?;

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -285,7 +285,7 @@ fn compress_files(
     formats: Vec<Extension>,
     output_file: fs::File,
     output_dir: &Path,
-    question_policy: QuestionPolicy
+    question_policy: QuestionPolicy,
 ) -> crate::Result<()> {
     // The next lines are for displaying the progress bar
     // If the input files contain a directory, then the total size will be underestimated
@@ -354,9 +354,11 @@ fn compress_files(
         }
         Zip => {
             eprintln!("{orange}[WARNING]{reset}", orange = *colors::ORANGE, reset = *colors::RESET);
-            eprintln!("\tThere is a limitation for .zip archives with extra extensions. (e.g. <file>.zip.gz)\
+            eprintln!(
+                "\tThere is a limitation for .zip archives with extra extensions. (e.g. <file>.zip.gz)\
             \n\tThe design of .zip makes it impossible to compress via stream, so it must be done entirely in memory.\
-            \n\tBy compressing .zip with extra compression formats, you can run out of RAM if the file is too large!");
+            \n\tBy compressing .zip with extra compression formats, you can run out of RAM if the file is too large!"
+            );
 
             // give user the option to continue compressing after warning is shown
             if !user_wants_to_continue_compressing(output_dir, question_policy)? {
@@ -513,9 +515,11 @@ fn decompress_file(
         }
         Zip => {
             eprintln!("{orange}[WARNING]{reset}", orange = *colors::ORANGE, reset = *colors::RESET);
-            eprintln!("\tThere is a limitation for .zip archives with extra extensions. (e.g. <file>.zip.gz)\
+            eprintln!(
+                "\tThere is a limitation for .zip archives with extra extensions. (e.g. <file>.zip.gz)\
             \n\tThe design of .zip makes it impossible to compress via stream, so it must be done entirely in memory.\
-            \n\tBy compressing .zip with extra compression formats, you can run out of RAM if the file is too large!");
+            \n\tBy compressing .zip with extra compression formats, you can run out of RAM if the file is too large!"
+            );
 
             // give user the option to continue decompressing after warning is shown
             if !user_wants_to_continue_decompressing(input_file_path, question_policy)? {
@@ -562,7 +566,7 @@ fn list_archive_contents(
     archive_path: &Path,
     formats: Vec<CompressionFormat>,
     list_options: ListOptions,
-    question_policy: QuestionPolicy
+    question_policy: QuestionPolicy,
 ) -> crate::Result<()> {
     let reader = fs::File::open(&archive_path)?;
 
@@ -605,9 +609,11 @@ fn list_archive_contents(
         Tar => crate::archive::tar::list_archive(reader)?,
         Zip => {
             eprintln!("{orange}[WARNING]{reset}", orange = *colors::ORANGE, reset = *colors::RESET);
-            eprintln!("\tThere is a limitation for .zip archives with extra extensions. (e.g. <file>.zip.gz)\
+            eprintln!(
+                "\tThere is a limitation for .zip archives with extra extensions. (e.g. <file>.zip.gz)\
             \n\tThe design of .zip makes it impossible to compress via stream, so it must be done entirely in memory.\
-            \n\tBy compressing .zip with extra compression formats, you can run out of RAM if the file is too large!");
+            \n\tBy compressing .zip with extra compression formats, you can run out of RAM if the file is too large!"
+            );
 
             // give user the option to continue decompressing after warning is shown
             if !user_wants_to_continue_decompressing(archive_path, question_policy)? {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -8,22 +8,13 @@ mod formatting;
 mod fs;
 mod question;
 
-pub use formatting::{
-    concatenate_os_str_list, nice_directory_display,
-    strip_cur_dir, to_utf, Bytes
-};
-pub use fs::{
-    cd_into_same_dir_as, clear_path, create_dir_if_non_existent,
-    dir_is_empty, try_infer_extension
-};
+pub use formatting::{concatenate_os_str_list, nice_directory_display, strip_cur_dir, to_utf, Bytes};
+pub use fs::{cd_into_same_dir_as, clear_path, create_dir_if_non_existent, dir_is_empty, try_infer_extension};
 pub use question::{
-    user_wants_to_continue_compressing, user_wants_to_continue_decompressing,
-    create_or_ask_overwrite, user_wants_to_overwrite,
-    QuestionPolicy
+    create_or_ask_overwrite, user_wants_to_continue_compressing, user_wants_to_continue_decompressing,
+    user_wants_to_overwrite, QuestionPolicy,
 };
-pub use utf8::{
-    get_invalid_utf8_paths, is_invalid_utf8
-};
+pub use utf8::{get_invalid_utf8_paths, is_invalid_utf8};
 
 mod utf8 {
     use std::{ffi::OsStr, path::PathBuf};

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -8,12 +8,22 @@ mod formatting;
 mod fs;
 mod question;
 
-pub use formatting::{concatenate_os_str_list, nice_directory_display, strip_cur_dir, to_utf, Bytes};
-pub use fs::{cd_into_same_dir_as, clear_path, create_dir_if_non_existent, dir_is_empty, try_infer_extension};
-pub use question::{
-    create_or_ask_overwrite, user_wants_to_continue_decompressing, user_wants_to_overwrite, QuestionPolicy,
+pub use formatting::{
+    concatenate_os_str_list, nice_directory_display,
+    strip_cur_dir, to_utf, Bytes
 };
-pub use utf8::{get_invalid_utf8_paths, is_invalid_utf8};
+pub use fs::{
+    cd_into_same_dir_as, clear_path, create_dir_if_non_existent,
+    dir_is_empty, try_infer_extension
+};
+pub use question::{
+    user_wants_to_continue_compressing, user_wants_to_continue_decompressing,
+    create_or_ask_overwrite, user_wants_to_overwrite,
+    QuestionPolicy
+};
+pub use utf8::{
+    get_invalid_utf8_paths, is_invalid_utf8
+};
 
 mod utf8 {
     use std::{ffi::OsStr, path::PathBuf};

--- a/src/utils/question.rs
+++ b/src/utils/question.rs
@@ -63,6 +63,20 @@ pub fn create_or_ask_overwrite(path: &Path, question_policy: QuestionPolicy) -> 
     }
 }
 
+/// Check if QuestionPolicy flags were set, otherwise, ask the user if they want to continue compressing.
+pub fn user_wants_to_continue_compressing(path: &Path, question_policy: QuestionPolicy) -> crate::Result<bool> {
+    match question_policy {
+        QuestionPolicy::AlwaysYes => Ok(true),
+        QuestionPolicy::AlwaysNo => Ok(false),
+        QuestionPolicy::Ask => {
+            let path = to_utf(strip_cur_dir(path));
+            let path = Some(path.as_str());
+            let placeholder = Some("FILE");
+            Confirmation::new("Do you want to continue compressing 'FILE'?", placeholder).ask(path)
+        }
+    }
+}
+
 /// Check if QuestionPolicy flags were set, otherwise, ask the user if they want to continue decompressing.
 pub fn user_wants_to_continue_decompressing(path: &Path, question_policy: QuestionPolicy) -> crate::Result<bool> {
     match question_policy {


### PR DESCRIPTION
resolves #178

also added functionality to ask user if they want to continue when working with `.zip` archives with extra compression formats (e.g. .zip.gz)