### PR TITLE
simple eprintln fixes

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -55,12 +55,12 @@ pub fn _info_helper(handle: &mut impl std::io::Write) {
     write!(handle, "{}[INFO]{} ", *YELLOW, *RESET).unwrap();
 }
 
-/// Macro that prints \[WARNING\] messages, wraps [`println`].
+/// Macro that prints \[WARNING\] messages, wraps [`eprintln`].
 #[macro_export]
 macro_rules! warning {
     ($($arg:tt)*) => {
         $crate::macros::_warning_helper();
-        println!($($arg)*);
+        eprintln!($($arg)*);
     };
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use ouch::{commands, Opts, Result};
 
 fn main() {
     if let Err(err) = run() {
-        println!("{}", err);
+        eprintln!("{}", err);
         std::process::exit(ouch::EXIT_FAILURE);
     }
 }


### PR DESCRIPTION
I found 2 instances where ouch should be using eprintln instead of println and fixed them here.