### PR TITLE
remove redundant user_wants_to_continue function

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -24,9 +24,9 @@ use crate::{
     progress::Progress,
     utils::{
         self, concatenate_os_str_list, dir_is_empty, nice_directory_display, to_utf, try_infer_extension,
-        user_wants_to_continue_compressing, user_wants_to_continue_decompressing,
+        user_wants_to_continue,
     },
-    warning, Opts, QuestionPolicy, Subcommand,
+    warning, Opts, QuestionPolicy, QuestionAction, Subcommand,
 };
 
 // Used in BufReader and BufWriter to perform less syscalls
@@ -361,7 +361,7 @@ fn compress_files(
             );
 
             // give user the option to continue compressing after warning is shown
-            if !user_wants_to_continue_compressing(output_dir, question_policy)? {
+            if !user_wants_to_continue(output_dir, question_policy, QuestionAction::Compression)? {
                 return Ok(());
             }
 
@@ -523,7 +523,7 @@ fn decompress_file(
             );
 
             // give user the option to continue decompressing after warning is shown
-            if !user_wants_to_continue_decompressing(input_file_path, question_policy)? {
+            if !user_wants_to_continue(input_file_path, question_policy, QuestionAction::Decompression)? {
                 return Ok(());
             }
 
@@ -618,7 +618,7 @@ fn list_archive_contents(
             );
 
             // give user the option to continue decompressing after warning is shown
-            if !user_wants_to_continue_decompressing(archive_path, question_policy)? {
+            if !user_wants_to_continue(archive_path, question_policy, QuestionAction::Decompression)? {
                 return Ok(());
             }
 
@@ -708,7 +708,7 @@ fn check_mime_type(
                 // Infering the file extension can have unpredicted consequences (e.g. the user just
                 // mistyped, ...) which we should always inform the user about.
                 info!(accessible, "Detected file: `{}` extension as `{}`", path.display(), detected_format);
-                if user_wants_to_continue_decompressing(path, question_policy)? {
+                if user_wants_to_continue(path, question_policy, QuestionAction::Decompression)? {
                     format.push(detected_format);
                 } else {
                     return Ok(ControlFlow::Break(()));
@@ -724,7 +724,7 @@ fn check_mime_type(
                     outer_ext,
                     detected_format
                 );
-                if !user_wants_to_continue_decompressing(path, question_policy)? {
+                if !user_wants_to_continue(path, question_policy, QuestionAction::Decompression)? {
                     return Ok(ControlFlow::Break(()));
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub mod opts;
 
 pub use error::{Error, Result};
 pub use opts::{Opts, Subcommand};
-pub use utils::QuestionPolicy;
+pub use utils::{QuestionPolicy, QuestionAction};
 
 /// The status code returned from `ouch` on error
 pub const EXIT_FAILURE: i32 = libc::EXIT_FAILURE;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -11,8 +11,8 @@ mod question;
 pub use formatting::{concatenate_os_str_list, nice_directory_display, strip_cur_dir, to_utf, Bytes};
 pub use fs::{cd_into_same_dir_as, clear_path, create_dir_if_non_existent, dir_is_empty, try_infer_extension};
 pub use question::{
-    create_or_ask_overwrite, user_wants_to_continue_compressing, user_wants_to_continue_decompressing,
-    user_wants_to_overwrite, QuestionPolicy,
+    create_or_ask_overwrite, user_wants_to_continue, user_wants_to_overwrite,
+    QuestionPolicy, QuestionAction,
 };
 pub use utf8::{get_invalid_utf8_paths, is_invalid_utf8};
 

--- a/src/utils/question.rs
+++ b/src/utils/question.rs
@@ -28,6 +28,16 @@ pub enum QuestionPolicy {
     AlwaysNo,
 }
 
+#[derive(Debug, PartialEq, Clone, Copy)]
+/// Determines which action is being questioned
+pub enum QuestionAction {
+    /// question called from a compression function
+    Compression,
+    /// question called from a decompression function
+    Decompression,
+}
+
+
 /// Check if QuestionPolicy flags were set, otherwise, ask user if they want to overwrite.
 pub fn user_wants_to_overwrite(path: &Path, question_policy: QuestionPolicy) -> crate::Result<bool> {
     match question_policy {
@@ -63,30 +73,20 @@ pub fn create_or_ask_overwrite(path: &Path, question_policy: QuestionPolicy) -> 
     }
 }
 
-/// Check if QuestionPolicy flags were set, otherwise, ask the user if they want to continue compressing.
-pub fn user_wants_to_continue_compressing(path: &Path, question_policy: QuestionPolicy) -> crate::Result<bool> {
+/// Check if QuestionPolicy flags were set, otherwise, ask the user if they want to continue.
+pub fn user_wants_to_continue(path: &Path, question_policy: QuestionPolicy, question_action: QuestionAction) -> crate::Result<bool> {
     match question_policy {
         QuestionPolicy::AlwaysYes => Ok(true),
         QuestionPolicy::AlwaysNo => Ok(false),
         QuestionPolicy::Ask => {
+            let action = match question_action {
+                QuestionAction::Compression => "compressing",
+                QuestionAction::Decompression => "decompressing",
+            };
             let path = to_utf(strip_cur_dir(path));
             let path = Some(path.as_str());
             let placeholder = Some("FILE");
-            Confirmation::new("Do you want to continue compressing 'FILE'?", placeholder).ask(path)
-        }
-    }
-}
-
-/// Check if QuestionPolicy flags were set, otherwise, ask the user if they want to continue decompressing.
-pub fn user_wants_to_continue_decompressing(path: &Path, question_policy: QuestionPolicy) -> crate::Result<bool> {
-    match question_policy {
-        QuestionPolicy::AlwaysYes => Ok(true),
-        QuestionPolicy::AlwaysNo => Ok(false),
-        QuestionPolicy::Ask => {
-            let path = to_utf(strip_cur_dir(path));
-            let path = Some(path.as_str());
-            let placeholder = Some("FILE");
-            Confirmation::new("Do you want to continue decompressing 'FILE'?", placeholder).ask(path)
+            Confirmation::new(&format!("Do you want to continue {} 'FILE'?", action), placeholder).ask(path)
         }
     }
 }


### PR DESCRIPTION
after #217, there were 2 functions in utils/questions.rs that were nearly identical, the only difference being the string passed to the user for confirmation. This PR merges the functions into a single function and creates an enum (`QuestionAction`) to pass to the function to choose the respective compression/decompression option for the string.