### PR TITLE
Actually use relative paths when extracting

### DIFF
--- a/src/archive/tar.rs
+++ b/src/archive/tar.rs
@@ -38,7 +38,8 @@ pub fn unpack_archive(
         // importance for most users, but would generate lots of
         // spoken text for users using screen readers, braille displays
         // and so on
-        info!(@display_handle, inaccessible, "{:?} extracted. ({})", output_folder.join(file.path()?), Bytes::new(file.size()));
+
+        info!(@display_handle, inaccessible, "{:?} extracted. ({})", utils::strip_cur_dir(&output_folder.join(file.path()?)), Bytes::new(file.size()));
 
         files_unpacked.push(file_path);
     }

--- a/src/utils/formatting.rs
+++ b/src/utils/formatting.rs
@@ -1,9 +1,4 @@
-use std::{
-    borrow::Cow,
-    cmp,
-    ffi::OsStr,
-    path::{Component, Path},
-};
+use std::{borrow::Cow, cmp, ffi::OsStr, path::Path};
 
 /// Converts an OsStr to utf8 with custom formatting.
 ///
@@ -19,7 +14,8 @@ pub fn to_utf(os_str: impl AsRef<OsStr>) -> String {
 /// normally used for presentation sake.
 /// If this function fails, it will return source path as a PathBuf.
 pub fn strip_cur_dir(source_path: &Path) -> &Path {
-    source_path.strip_prefix(Component::CurDir).unwrap_or(source_path)
+    let cwd = std::env::current_dir().unwrap_or_else(|_| Path::new(".").to_path_buf());
+    source_path.strip_prefix(cwd).unwrap_or(source_path)
 }
 
 /// Converts a slice of AsRef<OsStr> to comma separated String


### PR DESCRIPTION
In my testing this `source_path.strip_prefix(Component::CurDir).unwrap_or(source_path)` seems to only removes `./` but  if a path is already canonicalized it will fail to remove it example: `/home/user/..` -> fails to removes `/home/user`

By using the `current_dir` instead, it fixes the second case, but doesn't remove `./` which is maybe a good thing.