### PR TITLE
Cleanup integration tests

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -84,8 +84,8 @@ fn single_empty_file(ext: Extension, #[any(size_range(0..8).lift())] exts: Vec<F
     let archive = &dir.join(format!("file.{}", merge_extensions(ext, exts)));
     let after = &dir.join("after");
     write_random_content(&mut fs::File::create(before_file).unwrap(), &mut SmallRng::from_entropy());
-    ouch!("c", before_file, archive);
-    ouch!("d", archive, "-d", after);
+    ouch!("-A", "c", before_file, archive);
+    ouch!("-A", "d", archive, "-d", after);
     assert_same_directory(before, after, false);
 }
 
@@ -100,8 +100,8 @@ fn single_file(ext: Extension, #[any(size_range(0..8).lift())] exts: Vec<FileExt
     let archive = &dir.join(format!("file.{}", merge_extensions(ext, exts)));
     let after = &dir.join("after");
     fs::write(before_file, []).unwrap();
-    ouch!("c", before_file, archive);
-    ouch!("d", archive, "-d", after);
+    ouch!("-A", "c", before_file, archive);
+    ouch!("-A", "d", archive, "-d", after);
     assert_same_directory(before, after, false);
 }
 
@@ -120,7 +120,7 @@ fn multiple_files(
     let archive = &dir.join(format!("archive.{}", merge_extensions(&ext, exts)));
     let after = &dir.join("after");
     create_random_files(before_dir, depth, &mut SmallRng::from_entropy());
-    ouch!("c", before_dir, archive);
-    ouch!("d", archive, "-d", after);
+    ouch!("-A", "c", before_dir, archive);
+    ouch!("-A", "d", archive, "-d", after);
     assert_same_directory(before, after, !matches!(ext, DirectoryExtension::Zip));
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -18,11 +18,13 @@ use crate::utils::{assert_same_directory, write_random_content};
 enum DirectoryExtension {
     Tar,
     Tbz,
+    Tbz2,
     Tgz,
     Tlz4,
     Tlzma,
     Tsz,
     Txz,
+    Tzst,
     Zip,
 }
 
@@ -37,6 +39,7 @@ enum FileExtension {
     Lzma,
     Sz,
     Xz,
+    Zst,
 }
 
 #[derive(Arbitrary, Debug, Display)]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6,7 +6,7 @@ use std::{iter::once, path::PathBuf};
 use fs_err as fs;
 use parse_display::Display;
 use proptest::sample::size_range;
-use rand::{rngs::SmallRng, RngCore, SeedableRng};
+use rand::{rngs::SmallRng, Rng, SeedableRng};
 use tempfile::tempdir;
 use test_strategy::{proptest, Arbitrary};
 
@@ -60,12 +60,12 @@ fn create_random_files(dir: impl Into<PathBuf>, depth: u8, rng: &mut SmallRng) {
     let dir = &dir.into();
 
     // create 0 to 7 random files
-    for _ in 0..rng.next_u32() % 8 {
+    for _ in 0..rng.gen_range(0..8u32) {
         write_random_content(&mut tempfile::Builder::new().tempfile_in(dir).unwrap().keep().unwrap().0, rng);
     }
 
     // create more random files in 0 to 3 new directories
-    for _ in 0..rng.next_u32() % 4 {
+    for _ in 0..rng.gen_range(0..4u32) {
         create_random_files(&tempfile::tempdir_in(dir).unwrap().into_path(), depth - 1, rng);
     }
 }

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,7 +1,7 @@
 use std::{io::Write, path::PathBuf};
 
 use fs_err as fs;
-use rand::RngCore;
+use rand::{Rng, RngCore};
 
 #[macro_export]
 macro_rules! ouch {
@@ -15,9 +15,10 @@ macro_rules! ouch {
 
 // write random content to a file
 pub fn write_random_content(file: &mut impl Write, rng: &mut impl RngCore) {
-    let data = &mut Vec::with_capacity((rng.next_u32() % 8192) as usize);
-    rng.fill_bytes(data);
-    file.write_all(data).unwrap();
+    let mut data = Vec::new();
+    data.resize(rng.gen_range(0..8192), 0);
+    rng.fill_bytes(&mut data);
+    file.write_all(&data).unwrap();
 }
 
 // check that two directories have the exact same content recursively


### PR DESCRIPTION
There were a few different changes here:

- 5775d4f26804433d81dc86f61ac22df2e04992ec made it so that the dummy files are actually filled with contents. `.fill_bytes()` will overwrite existing contents. It won't push on any new data even if there is capacity for it
- 1ad3652a40c17c4945863eda35f22a9799c436ca just switched to some nicer syntax for generating a random value in a range
- c5e9696f8ddfda02eb57ac9c6c2e6fb77d0b4e34 added extensions to test for all the formats listed in the README
- f3d564f8b00ccb9f407f6130240e772449efacd3 runs the integration tests with the accessibility flag to drastically reduce the runtime
  - This change brought the time to run integration tests down from around 2 minutes to less than 30 seconds for me
  - I went through a lot of effort trying to track down what specifically was slow here. My current best guess is that there is that `indicatif` runs much slower in a spawned command for some reason. I'll be spending some more time trying to track down the root cause of this