### PR TITLE
fix: missing `#[must_use]` attribute on a method returning `Self`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -86,17 +86,20 @@ impl Display for FinalError {
 
 impl FinalError {
     /// Only constructor
+    #[must_use]
     pub fn with_title(title: impl ToString) -> Self {
         Self { title: title.to_string(), details: vec![], hints: vec![] }
     }
 
     /// Add one detail line, can have multiple
+    #[must_use]
     pub fn detail(mut self, detail: impl ToString) -> Self {
         self.details.push(detail.to_string());
         self
     }
 
     /// Add one hint line, can have multiple
+    #[must_use]
     pub fn hint(mut self, hint: impl ToString) -> Self {
         self.hints.push(hint.to_string());
         self


### PR DESCRIPTION
Ref.: https://rust-lang.github.io/rust-clippy/master/index.html#return_self_not_must_use