### PR TITLE
fix: remove single quotes from clap doc comments

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -120,7 +120,7 @@ pub fn run(
             let output_file = fs::File::create(&output_path)?;
 
             if !represents_several_files(&files) {
-                // It's possible the file is already partially compressed so we don't want to compress it again
+                // It is possible the file is already partially compressed so we don't want to compress it again
                 // `ouch compress file.tar.gz file.tar.gz.xz` should produce `file.tar.gz.xz` and not `file.tar.gz.tar.gz.xz`
                 let input_extensions = extension::extensions_from_path(&files[0]);
 


### PR DESCRIPTION
Apparently, clap_complete doesn't properly escape single quotes in doc
comments, leading to broken shell completions for zsh. To circumvent
this, I've removed the single quote in the one place where it shouldn't
have been in the first place ("it's" vs "its", contraction vs possessive
pronoun), and replaced "it's" with "it is" in the other place.

Reference to upstream issue: https://github.com/clap-rs/clap/issues/1596