### PR TITLE
Fix new completions generation env var

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -42,6 +42,7 @@ include!("src/opts.rs");
 
 fn main() {
     println!("cargo:rerun-if-env-changed=GEN_COMPLETIONS");
+    println!("cargo:rerun-if-env-changed=OUCH_COMPLETIONS_FOLDER");
 
     if let Some(completions_output_directory) = detect_completions_output_directory() {
         create_dir_all(&completions_output_directory).expect("Could not create shell completions output folder.");

--- a/build.rs
+++ b/build.rs
@@ -35,8 +35,10 @@
 /// The _"195b34a8adca6ec3"_ part is a hash that might change between runs.
 use std::{env, fs::create_dir_all, path::Path};
 
-use clap::{ArgEnum, IntoApp};
+use clap::IntoApp;
 use clap_complete::{generate_to, Shell};
+
+const TARGET_SHELLS: &[Shell] = &[Shell::Bash, Shell::Zsh, Shell::Fish];
 
 include!("src/opts.rs");
 
@@ -48,7 +50,7 @@ fn main() {
         create_dir_all(&completions_output_directory).expect("Could not create shell completions output folder.");
         let app = &mut Opts::command();
 
-        for shell in Shell::value_variants() {
+        for shell in TARGET_SHELLS {
             generate_to(*shell, app, "ouch", &completions_output_directory)
                 .unwrap_or_else(|err| panic!("Failed to generate shell completions for {}: {}.", shell, err));
         }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -10,6 +10,9 @@ use clap::{Parser, ValueHint};
 /// Repository: https://github.com/ouch-org/ouch
 #[derive(Parser, Debug)]
 #[clap(about, version)]
+// Ignore bare urls in the documentation of this file because the doc comments
+// are also being used by Clap's --help generation
+#[allow(rustdoc::bare_urls)]
 pub struct Opts {
     /// Skip [Y/n] questions positively.
     #[clap(short, long, conflicts_with = "no", global = true)]
@@ -48,6 +51,7 @@ pub struct Opts {
 // Clap commands:
 //  - `help`
 #[derive(Parser, PartialEq, Eq, Debug)]
+#[allow(rustdoc::bare_urls)]
 pub enum Subcommand {
     /// Compress one or more files into one output file.
     #[clap(alias = "c")]

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -126,8 +126,8 @@ pub fn try_infer_extension(path: &Path) -> Option<Extension> {
 }
 
 /// Returns true if a path is a symlink.
-/// This is the same as the nightly https://doc.rust-lang.org/std/path/struct.Path.html#method.is_symlink
-// Useful to detect broken symlinks when compressing. (So we can safely ignore them)
+/// This is the same as the nightly <https://doc.rust-lang.org/std/path/struct.Path.html#method.is_symlink>
+/// Useful to detect broken symlinks when compressing. (So we can safely ignore them)
 pub fn is_symlink(path: &Path) -> bool {
     fs::symlink_metadata(path)
         .map(|m| m.file_type().is_symlink())


### PR DESCRIPTION
This PR fixes the new env var not triggering a build.rs run.

Also, create a folder for each shell completion file.

```plain
.
├── bash
│   └── ouch.bash
├── fish
│   └── ouch.fish
└── zsh
    └── _ouch
```