### PR TITLE
refac: use `Lazy` to optimize `env::current_dir` repeated call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Categories Used:
 - Use `Cow<'static, str>` in `FinalError` [\#246](https://github.com/ouch-org/ouch/pull/246) ([vrmiguel](https://github.com/vrmiguel))
 - Don't allocate when possible in `to_utf`, `nice_directory_display` [\#249](https://github.com/ouch-org/ouch/pull/249) ([vrmiguel](https://github.com/vrmiguel))
 - Allow overriding the completions output directory [\#251]](https://github.com/ouch-org/ouch/pull/251) ([jcgruenhage](https://github.com/jcgruenhage))
+- Use Lazy to optimize env::current_dir repeated call [\#261]](https://github.com/ouch-org/ouch/pull/261) ([marcospb19](https://github.com/marcospb19))
 
 ### Tweaks
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,12 +14,18 @@ pub mod utils;
 /// CLI argparsing definitions, using `clap`.
 pub mod opts;
 
+use std::{env, path::PathBuf};
+
 use error::{Error, Result};
+use once_cell::sync::Lazy;
 use opts::{Opts, Subcommand};
 use utils::{QuestionAction, QuestionPolicy};
 
 // Used in BufReader and BufWriter to perform less syscalls
 const BUFFER_CAPACITY: usize = 1024 * 32;
+
+/// Current directory or empty directory
+static CURRENT_DIRECTORY: Lazy<PathBuf> = Lazy::new(|| env::current_dir().unwrap_or_default());
 
 /// The status code returned from `ouch` on error
 pub const EXIT_FAILURE: i32 = libc::EXIT_FAILURE;

--- a/src/utils/formatting.rs
+++ b/src/utils/formatting.rs
@@ -1,4 +1,6 @@
-use std::{borrow::Cow, cmp, env, path::Path};
+use std::{borrow::Cow, cmp, path::Path};
+
+use crate::CURRENT_DIRECTORY;
 
 /// Converts an OsStr to utf8 with custom formatting.
 ///
@@ -17,12 +19,7 @@ pub fn to_utf(os_str: &Path) -> Cow<str> {
 /// Removes the current dir from the beginning of a path as it's redundant information,
 /// useful for presentation sake.
 pub fn strip_cur_dir(source_path: &Path) -> &Path {
-    let current_dir = env::current_dir();
-
-    let current_dir = match &current_dir {
-        Ok(inner) => inner.as_path(),
-        Err(_) => Path::new(""),
-    };
+    let current_dir = &*CURRENT_DIRECTORY;
 
     source_path.strip_prefix(current_dir).unwrap_or(source_path)
 }


### PR DESCRIPTION
`env::current_dir` is repeatedly called when presenting
the path to the user in the `strip_cur_dir` function.

This will effectively change logged paths if we `cd` into some other directory, possibly changing from:

`decompressing at file.txt` to `decompressing at dir1/dir2/file.txt`