### PR TITLE
Fix the `decompress` `-d` argument description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Categories Used:
 - Update dependencies [\#253](https://github.com/ouch-org/ouch/pull/253) ([Crypto-Spartan](https://github.com/Crypto-Spartan))
 - Update dependencies [\#257](https://github.com/ouch-org/ouch/pull/257) ([Artturin](https://github.com/Artturin))
 - Add pull request template [\#263](https://github.com/ouch-org/ouch/pull/263) ([figsoda](https://github.com/figsoda))
+- Clean up the description for the `-o/--dir` argument to `decompress` [\#264](https://github.com/ouch-org/ouch/pull/264) ([hivehand](https://github.com/hivehand))
 
 ### New Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ Categories Used:
 - Update dependencies [\#253](https://github.com/ouch-org/ouch/pull/253) ([Crypto-Spartan](https://github.com/Crypto-Spartan))
 - Update dependencies [\#257](https://github.com/ouch-org/ouch/pull/257) ([Artturin](https://github.com/Artturin))
 - Add pull request template [\#263](https://github.com/ouch-org/ouch/pull/263) ([figsoda](https://github.com/figsoda))
-- Clean up the description for the `-o/--dir` argument to `decompress` [\#264](https://github.com/ouch-org/ouch/pull/264) ([hivehand](https://github.com/hivehand))
+- Clean up the description for the `-d/--dir` argument to `decompress` [\#264](https://github.com/ouch-org/ouch/pull/264) ([hivehand](https://github.com/hivehand))
 
 ### New Contributors
 
@@ -111,7 +111,7 @@ Categories Used:
 - Implement command 'list' to show archive contents [\#129](https://github.com/ouch-org/ouch/pull/129) ([AntonHermann](https://github.com/AntonHermann))
 - Print number of unpacked files by [\#130](https://github.com/ouch-org/ouch/pull/130) ([dcariotti](https://github.com/dcariotti))
 
-**Disclaimer: _Our installation script does not support installing man pages and shell completions yet, but PRs are welcome!_ **
+**Disclaimer: _Our installation script does not support installing man pages and shell completions yet, but PRs are welcome!_**
 
 ### Bug Fixes
 

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -71,7 +71,7 @@ pub enum Subcommand {
         #[clap(required = true, min_values = 1)]
         files: Vec<PathBuf>,
 
-        /// Choose to  files in a directory other than the current
+        /// Place results in a directory other than the current one.
         #[clap(short = 'd', long = "dir", value_hint = ValueHint::DirPath)]
         output_dir: Option<PathBuf>,
     },


### PR DESCRIPTION
This corrects the description of said argument. (Feel free to discard my phrasing and replace it with your own. I'm just submitting mine to spare you possible work.)

Fixes #264.