### PR TITLE
fix: respect file permissions when compressing zip files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,7 @@ Categories Used:
 - CI: Rewrite [\#135](https://github.com/ouch-org/ouch/pull/135) ([figsoda](https://github.com/figsoda))
 - Improving error messages and removing dead error treatment code [\#140](https://github.com/ouch-org/ouch/pull/140) ([marcospb19](https://github.com/marcospb19))
 - Apply clippy lints and simplify smart_unpack [\#267](https://github.com/ouch-org/ouch/pull/267) ([figsoda](https://github.com/figsoda))
+- Respect file permissions when compressing zip files [\#271](https://github.com/ouch-org/ouch/pull/271) ([figsoda](https://github.com/figsoda))
 
 ### Tweaks
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_executable"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa9acdc6d67b75e626ad644734e8bc6df893d9cd2a834129065d3dd6158ea9c8"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,6 +534,7 @@ dependencies = [
  "ignore",
  "indicatif",
  "infer",
+ "is_executable",
  "libc",
  "linked-hash-map",
  "lzzzz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ indicatif = "0.16.2"
 [target.'cfg(unix)'.dependencies]
 time = { version = "0.3.9", default-features = false }
 
+[target.'cfg(not(unix))'.dependencies]
+is_executable = "1.0.1"
+
 [build-dependencies]
 clap = { version = "3.1.18", features = ["derive", "env"] }
 clap_complete = "3.1.4"


### PR DESCRIPTION
<!--
Make sure to check out CONTRIBUTING.md.
Don't forget to add a CHANGELOG.md entry!
-->

Only tested on linux

on unix platforms: keeps file permissions

on non-unix platforms: sets unix permissions to 755 if the file is executable (I'm not sure if I should keep this because iirc ouch doesn't respect permissions when decompressing zip files on non-unix platforms)