### PR TITLE
Warn user if file extension is passed as file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Categories Used:
 - Apply clippy lints and simplify smart_unpack [\#267](https://github.com/ouch-org/ouch/pull/267) ([figsoda](https://github.com/figsoda))
 - Respect file permissions when compressing zip files [\#271](https://github.com/ouch-org/ouch/pull/271) ([figsoda](https://github.com/figsoda))
 - Apply clippy lints [\#273](https://github.com/ouch-org/ouch/pull/273) ([figsoda](https://github.com/figsoda))
+- Warn user if file extension is passed as file name [\#277](https://github.com/ouch-org/ouch/pull/277) ([marcospb19](https://github.com/marcospb19))
 
 ### Tweaks
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,7 +34,6 @@ impl Opts {
             (true, true) => unreachable!(),
         };
 
-        // TODO: change this to be just a single function call?
         let file_visibility_policy = FileVisibilityPolicy::new()
             .read_git_exclude(opts.gitignore)
             .read_ignore(opts.gitignore)

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -3,6 +3,7 @@
 use std::{ffi::OsStr, fmt, path::Path};
 
 use self::CompressionFormat::*;
+use crate::warning;
 
 /// A wrapper around `CompressionFormat` that allows combinations like `tgz`
 #[derive(Debug, Clone, Eq)]
@@ -103,18 +104,19 @@ pub const SUPPORTED_EXTENSIONS: &[&str] = &[
     "zst",
 ];
 
-/// Extracts extensions from a path,
-/// return both the remaining path and the list of extension objects
+/// Extracts extensions from a path.
+///
+/// Returns both the remaining path and the list of extension objects
 pub fn separate_known_extensions_from_name(mut path: &Path) -> (&Path, Vec<Extension>) {
-    // // TODO: check for file names with the name of an extension
-    // // TODO2: warn the user that currently .tar.gz is a .gz file named .tar
-    //
-    // let all = ["tar", "zip", "bz", "bz2", "gz", "xz", "lzma", "lz"];
-    // if path.file_name().is_some() && all.iter().any(|ext| path.file_name().unwrap() == *ext) {
-    //     todo!("we found a extension in the path name instead, what to do with this???");
-    // }
-
     let mut extensions = vec![];
+
+    if let Some(file_stem) = path.file_stem().and_then(OsStr::to_str) {
+        let file_stem = file_stem.trim_matches('.');
+
+        if SUPPORTED_EXTENSIONS.contains(&file_stem) {
+            warning!("Received a file with name '{file_stem}', but {file_stem} was expected as the extension.");
+        }
+    }
 
     // While there is known extensions at the tail, grab them
     while let Some(extension) = path.extension().and_then(OsStr::to_str) {


### PR DESCRIPTION
example: `.tar.gz` is a file named .tar with extension `.gz`

this can be confusing because people might expect a
path `'.tar.gz'` to be a `.tar.gz` archive, but it's not
