### PR TITLE
Remove automatic detection for partial compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ Categories Used:
 - New Features - new features added to ouch itself, not CI
 - Bug Fixes
 - Improvements - general enhancements
-- Tweaks - Anything that doesn't fit into other categories, small typo fixes, most CI stuff, meta changes (e.g. README updates), etc.
+- Tweaks - anything that doesn't fit into other categories, small typo fixes, most CI stuff,
+  meta changes (e.g. README updates), etc.
+- Regression - removal of a feature (that might be readded, or reworked in the future)
 
 **Bullet points in chronological order by PR**
 
@@ -99,6 +101,10 @@ Categories Used:
 - Show subcommand aliases on --help [\#275](https://github.com/ouch-org/ouch/pull/275) ([marcospb19](https://github.com/marcospb19))
 - Update dependencies [\#276](https://github.com/ouch-org/ouch/pull/276) ([figsoda](https://github.com/figsoda))
 - Rewrite progress module [\#280](https://github.com/ouch-org/ouch/pull/280) ([figsoda](https://github.com/figsoda))
+
+### Regression
+
+- Remove automatic detection for partial compression [\#286](https://github.com/ouch-org/ouch/pull/286) ([marcospb19](https://github.com/marcospb19))
 
 ### New Contributors
 


### PR DESCRIPTION
Fixes #285 and fixes #282 with a feature regression.

# What is the problem this feature used to solve?

Ouch infers compression formats from file extensions.

```
ouch compress file file.tar.gz
```

From the output file, Ouch infers the formats `[Tar, Gz]`.

---

However, sometimes you want to compress a file that is already compressed, for example:

```
ouch compress file.tar file.tar.gz
```

Again, Ouch infers the formats `[Tar, Gz]` and compresses `file.tar` with these formats in mind, this is a problem because the end result is an archive of type `[Tar, Tar, Gz]`.

Ouch should, in some way, enable the user to compress this just using `[Gz]` (I'm calling this `partial compression`, because the archive is already partially compressed).

# The feature

I implemented (with the code removed by this PR) a tiny automatic detection for when formats match.

Problems with automatic detection:

1. Current implementation is flawed (thanks to me, a lot of false-positives and format mismatchs).
2. It's counter-intuitive and unpredictable behavior (especially for first-timers).
3. Users don't notice when it happens because we already log so much.
4. Does not work with `stdout` and `stdin`, because those aren't named.
5. Cannot force partial compression without renaming files manually.

# Solution

Regress this feature and implement [`--format` flag](#134).
