### PR TITLE
Improve error message when compressing folder with single-file formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Categories Used:
 - Check for errors when setting the last modified time [\#278](https://github.com/ouch-org/ouch/pull/278) ([marcospb19](https://github.com/marcospb19))
 - Use to the humansize crate for formatting human-readable file sizes [\#281](https://github.com/ouch-org/ouch/pull/281) ([figsoda](https://github.com/figsoda))
 - Reactivate CI targets for ARM Linux and Windows MinGW [\#289](https://github.com/ouch-org/ouch/pull/289) ([figsoda](https://github.com/figsoda))
+- Improve error message when compressing folder with single-file formats [\#303](https://github.com/ouch-org/ouch/pull/303) ([marcospb19](https://github.com/marcospb19))
 
 ### Tweaks
 

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -2,7 +2,6 @@
 
 use std::{
     env,
-    fs::ReadDir,
     io::Read,
     path::{Path, PathBuf},
 };
@@ -11,13 +10,6 @@ use fs_err as fs;
 
 use super::{to_utf, user_wants_to_overwrite};
 use crate::{extension::Extension, info, QuestionPolicy};
-
-/// Checks if given path points to an empty directory.
-pub fn dir_is_empty(dir_path: &Path) -> bool {
-    let is_empty = |mut rd: ReadDir| rd.next().is_none();
-
-    dir_path.read_dir().map(is_empty).unwrap_or_default()
-}
 
 /// Remove `path` asking the user to overwrite if necessary.
 ///

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -12,8 +12,7 @@ mod question;
 pub use file_visibility::FileVisibilityPolicy;
 pub use formatting::{nice_directory_display, pretty_format_list_of_paths, strip_cur_dir, to_utf};
 pub use fs::{
-    cd_into_same_dir_as, clear_path, create_dir_if_non_existent, dir_is_empty, is_symlink, remove_file_or_dir,
-    try_infer_extension,
+    cd_into_same_dir_as, clear_path, create_dir_if_non_existent, is_symlink, remove_file_or_dir, try_infer_extension,
 };
 pub use question::{
     ask_to_create_file, user_wants_to_continue, user_wants_to_overwrite, QuestionAction, QuestionPolicy,


### PR DESCRIPTION
Closes #268.

Before this PR:

```
$ ouch compress empty-folder file.gz.xz.bz
[ERROR] failed to read from file `/home/marcospb19/empty-folder`
```

After the PR:

```
$ ouch compress empty-folder file.gz.xz.bz
[ERROR] Cannot compress to 'file.gz.xz.bz'.
 - You are trying to compress a folder.
 - The compression format 'gz' does not accept multiple files.
 - Formats that bundle files into an archive are .tar and .zip.

hint: Try inserting '.tar' or '.zip' before 'gz'.
hint: From: file.gz.xz.bz
hint: To:   file.tar.gz.xz.bz
```