### PR TITLE
Check for EOF when asking questions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Categories Used:
 - Fix incorrect warnings for decompression [\#270](https://github.com/ouch-org/ouch/pull/270) ([figsoda](https://github.com/figsoda))
 - Fix infinite compression if output file is inside the input folder [\#288](https://github.com/ouch-org/ouch/pull/288) ([figsoda](https://github.com/figsoda))
 - Fix not overwriting a folder when compressing [\#295](https://github.com/ouch-org/ouch/pull/295) ([marcospb19](https://github.com/marcospb19))
+- Check for EOF when asking questions [\#311](https://github.com/ouch-org/ouch/pull/311) ([marcospb19](https://github.com/marcospb19))
 
 ### Improvements
 

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -9,6 +9,7 @@ macro_rules! ouch {
     ($($e:expr),*) => {
         $crate::utils::cargo_bin()
             $(.arg($e))*
+            .arg("--yes")
             .unwrap();
     }
 }


### PR DESCRIPTION
When invoking Ouch from shell scripts, it is likely that questions will
be left unanswered with EOF, this PR adds a check to prevent Ouch
from interpreting EOF as Yes in Y/N questions.

![image](https://user-images.githubusercontent.com/38900226/203464046-cdda121e-08f6-4687-9eb7-c34f8670e372.png)

