### PR TITLE
Decrease number of cargo manifest keywords

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 readme = "README.md"
 repository = "https://github.com/ouch-org/ouch"
 license = "MIT"
-keywords = ["decompression", "compression", "zip", "tar", "gzip", "accessibility", "a11y"]
+keywords = ["decompression", "compression", "cli"]
 categories = ["command-line-utilities", "compression", "encoding"]
 description = "A command-line utility for easily compressing and decompressing files and directories."
 


### PR DESCRIPTION
crates.io requires a maximum of 5 keywords for each crate, this PR
removes some keywords to fit this requirement in order to allow
publishing Ouch 0.4.0.