### PR TITLE
Use `ubyte` instead of `humansize`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,15 +349,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "humansize"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
-dependencies = [
- "libm",
-]
-
-[[package]]
 name = "ignore"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,12 +452,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
-name = "libm"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
-
-[[package]]
 name = "libz-sys"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,7 +553,6 @@ dependencies = [
  "filetime",
  "flate2",
  "fs-err",
- "humansize",
  "ignore",
  "infer",
  "is_executable",
@@ -585,6 +569,7 @@ dependencies = [
  "tempfile",
  "test-strategy",
  "time",
+ "ubyte",
  "xz2",
  "zip",
  "zstd",
@@ -990,6 +975,12 @@ checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
 dependencies = [
  "time-core",
 ]
+
+[[package]]
+name = "ubyte"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c81f0dae7d286ad0d9366d7679a77934cfc3cf3a8d67e82669794412b2368fe6"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ clap = { version = "4.0.32", features = ["derive", "env"] }
 filetime = "0.2.19"
 flate2 = { version = "1.0.25", default-features = false }
 fs-err = "2.9.0"
-humansize = "2.1.3"
 ignore = "0.4.18"
 libc = "0.2.139"
 linked-hash-map = "0.5.6"
@@ -28,6 +27,7 @@ same-file = "1.0.6"
 snap = "1.1.0"
 tar = "0.4.38"
 tempfile = "3.3.0"
+ubyte = { version = "0.10.3", default-features = false }
 xz2 = "0.1.7"
 zip = { version = "0.6.3", default-features = false, features = ["time"] }
 zstd = { version = "0.12.1", default-features = false }

--- a/src/archive/tar.rs
+++ b/src/archive/tar.rs
@@ -9,8 +9,8 @@ use std::{
 };
 
 use fs_err as fs;
-use humansize::{format_size, DECIMAL};
 use same_file::Handle;
+use ubyte::ToByteUnit;
 
 use crate::{
     error::FinalError,
@@ -42,7 +42,7 @@ pub fn unpack_archive(reader: Box<dyn Read>, output_folder: &Path, quiet: bool) 
                 inaccessible,
                 "{:?} extracted. ({})",
                 utils::strip_cur_dir(&output_folder.join(file.path()?)),
-                format_size(file.size(), DECIMAL),
+                file.size().bytes(),
             );
 
             files_unpacked.push(file_path);

--- a/src/archive/zip.rs
+++ b/src/archive/zip.rs
@@ -12,8 +12,8 @@ use std::{
 
 use filetime::{set_file_mtime, FileTime};
 use fs_err as fs;
-use humansize::{format_size, DECIMAL};
 use same_file::Handle;
+use ubyte::ToByteUnit;
 use zip::{self, read::ZipFile, DateTime, ZipArchive};
 
 use crate::{
@@ -73,7 +73,7 @@ where
                         inaccessible,
                         "{:?} extracted. ({})",
                         file_path.display(),
-                        format_size(file.size(), DECIMAL),
+                        file.size().bytes()
                     );
                 }
 


### PR DESCRIPTION
Uses Sergio Benitez's `ubyte` crate instead of `humansize`.

The main reasoning for this is removing the use of `humansize`'s inefficient `format_size` function. It could be replaced by `SizeFormatter::new(bytes, DECIMAL);` but that seems too verbose. `ubyte`'s usage instead looks like `size.bytes()` and does not allocate

As another very minor win we get to stop compiling Rust's libm

P.S. I'm not sure why we stopped using our own `Bytes` struct