### PR TITLE
Stop keeping track of the names of unpacked files

### DIFF
--- a/src/archive/tar.rs
+++ b/src/archive/tar.rs
@@ -22,15 +22,14 @@ use crate::{
 
 /// Unpacks the archive given by `archive` into the folder given by `into`.
 /// Assumes that output_folder is empty
-pub fn unpack_archive(reader: Box<dyn Read>, output_folder: &Path, quiet: bool) -> crate::Result<Vec<PathBuf>> {
+pub fn unpack_archive(reader: Box<dyn Read>, output_folder: &Path, quiet: bool) -> crate::Result<usize> {
     assert!(output_folder.read_dir().expect("dir exists").count() == 0);
     let mut archive = tar::Archive::new(reader);
 
-    let mut files_unpacked = vec![];
+    let mut files_unpacked = 0;
     for file in archive.entries()? {
         let mut file = file?;
 
-        let file_path = output_folder.join(file.path()?);
         file.unpack_in(output_folder)?;
 
         // This is printed for every file in the archive and has little
@@ -45,7 +44,7 @@ pub fn unpack_archive(reader: Box<dyn Read>, output_folder: &Path, quiet: bool) 
                 file.size().bytes(),
             );
 
-            files_unpacked.push(file_path);
+            files_unpacked += 1;
         }
     }
 

--- a/src/archive/zip.rs
+++ b/src/archive/zip.rs
@@ -29,13 +29,13 @@ use crate::{
 
 /// Unpacks the archive given by `archive` into the folder given by `output_folder`.
 /// Assumes that output_folder is empty
-pub fn unpack_archive<R>(mut archive: ZipArchive<R>, output_folder: &Path, quiet: bool) -> crate::Result<Vec<PathBuf>>
+pub fn unpack_archive<R>(mut archive: ZipArchive<R>, output_folder: &Path, quiet: bool) -> crate::Result<usize>
 where
     R: Read + Seek,
 {
     assert!(output_folder.read_dir().expect("dir exists").count() == 0);
 
-    let mut unpacked_files = Vec::with_capacity(archive.len());
+    let mut unpacked_files = 0;
 
     for idx in 0..archive.len() {
         let mut file = archive.by_index(idx)?;
@@ -87,7 +87,7 @@ where
         #[cfg(unix)]
         unix_set_permissions(&file_path, &file)?;
 
-        unpacked_files.push(file_path);
+        unpacked_files += 1;
     }
 
     Ok(unpacked_files)


### PR DESCRIPTION
Since we only use the return of `smart_unpack`  to print out the amount of unpacked files, we don't have to build the expensive Vec of unpacked PathBufs, instead only returning the actual number of unpacked files