### PR TITLE
fix handling of unknown extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ Categories Used:
 
 - Multi-threaded compression for gzip and snappy using gzp [\#348](https://github.com/ouch-org/ouch/pull/348) ([figsoda](https://github.com/figsoda))
 
+### Bug fixes
+
+- Fix handling of unknown extensions during decompression [\#355](https://github.com/ouch-org/ouch/pull/355) ([figsoda](https://github.com/figsoda))
+
 ## [0.4.1](https://github.com/ouch-org/ouch/compare/0.4.0...0.4.1)
 
 ### New Features

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -113,11 +113,12 @@ fn to_extension(ext: &[u8]) -> Option<Extension> {
     ))
 }
 
-fn split_extension<'a>(name: &mut &'a [u8]) -> Option<&'a [u8]> {
+fn split_extension(name: &mut &[u8]) -> Option<Extension> {
     let (new_name, ext) = name.rsplit_once_str(b".")?;
     if matches!(new_name, b"" | b"." | b"..") {
         return None;
     }
+    let ext = to_extension(ext)?;
     *name = new_name;
     Some(ext)
 }
@@ -149,7 +150,7 @@ pub fn separate_known_extensions_from_name(path: &Path) -> (&Path, Vec<Extension
     };
 
     // While there is known extensions at the tail, grab them
-    while let Some(extension) = split_extension(&mut name).and_then(to_extension) {
+    while let Some(extension) = split_extension(&mut name) {
         extensions.insert(0, extension);
     }
 


### PR DESCRIPTION
fixes #351 

`ouch d a.b.gz` now correctly outputs to `a.b` instead of `a`

this was probably a regression caused by https://github.com/ouch-org/ouch/pull/330