### PR TITLE
Create `check` module

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -27,7 +27,7 @@ use clap::{CommandFactory, ValueEnum};
 use clap_complete::{generate_to, Shell};
 use clap_mangen::Man;
 
-include!("src/opts.rs");
+include!("src/cli/args.rs");
 
 fn main() {
     println!("cargo:rerun-if-env-changed=OUCH_ARTIFACTS_FOLDER");
@@ -35,7 +35,7 @@ fn main() {
     if let Some(dir) = env::var_os("OUCH_ARTIFACTS_FOLDER") {
         let out = &Path::new(&dir);
         create_dir_all(out).unwrap();
-        let cmd = &mut Opts::command();
+        let cmd = &mut CliArgs::command();
 
         Man::new(cmd.clone())
             .render(&mut File::create(out.join("ouch.1")).unwrap())

--- a/src/check.rs
+++ b/src/check.rs
@@ -150,3 +150,19 @@ pub fn check_missing_formats_when_decompressing(files: &[PathBuf], formats: &[Ve
     }
     Ok(())
 }
+
+/// Check if there is a first format when compressing, and returns it.
+pub fn check_first_format_when_compressing<'a>(formats: &'a [Extension], output_path: &Path) -> Result<&'a Extension> {
+    formats.first().ok_or_else(|| {
+        let output_path = EscapedPathDisplay::new(output_path);
+        FinalError::with_title(format!("Cannot compress to '{output_path}'."))
+            .detail("You shall supply the compression format")
+            .hint("Try adding supported extensions (see --help):")
+            .hint(format!("  ouch compress <FILES>... {output_path}.tar.gz"))
+            .hint(format!("  ouch compress <FILES>... {output_path}.zip"))
+            .hint("")
+            .hint("Alternatively, you can overwrite this option by using the '--format' flag:")
+            .hint(format!("  ouch compress <FILES>... {output_path} --format tar.gz"))
+            .into()
+    })
+}

--- a/src/check.rs
+++ b/src/check.rs
@@ -1,0 +1,58 @@
+use std::{ops::ControlFlow, path::PathBuf};
+
+use crate::{
+    extension::Extension,
+    info,
+    utils::{try_infer_extension, user_wants_to_continue},
+    warning, QuestionAction, QuestionPolicy,
+};
+
+pub fn check_mime_type(
+    files: &[PathBuf],
+    formats: &mut [Vec<Extension>],
+    question_policy: QuestionPolicy,
+) -> crate::Result<ControlFlow<()>> {
+    for (path, format) in files.iter().zip(formats.iter_mut()) {
+        if format.is_empty() {
+            // File with no extension
+            // Try to detect it automatically and prompt the user about it
+            if let Some(detected_format) = try_infer_extension(path) {
+                // Inferring the file extension can have unpredicted consequences (e.g. the user just
+                // mistyped, ...) which we should always inform the user about.
+                info!(
+                    accessible,
+                    "Detected file: `{}` extension as `{}`",
+                    path.display(),
+                    detected_format
+                );
+                if user_wants_to_continue(path, question_policy, QuestionAction::Decompression)? {
+                    format.push(detected_format);
+                } else {
+                    return Ok(ControlFlow::Break(()));
+                }
+            }
+        } else if let Some(detected_format) = try_infer_extension(path) {
+            // File ending with extension
+            // Try to detect the extension and warn the user if it differs from the written one
+            let outer_ext = format.iter().next_back().unwrap();
+            if !outer_ext
+                .compression_formats
+                .ends_with(detected_format.compression_formats)
+            {
+                warning!(
+                    "The file extension: `{}` differ from the detected extension: `{}`",
+                    outer_ext,
+                    detected_format
+                );
+                if !user_wants_to_continue(path, question_policy, QuestionAction::Decompression)? {
+                    return Ok(ControlFlow::Break(()));
+                }
+            }
+        } else {
+            // NOTE: If this actually produces no false positives, we can upgrade it in the future
+            // to a warning and ask the user if he wants to continue decompressing.
+            info!(accessible, "Could not detect the extension of `{}`", path.display());
+        }
+    }
+    Ok(ControlFlow::Continue(()))
+}

--- a/src/check.rs
+++ b/src/check.rs
@@ -169,6 +169,8 @@ pub fn check_first_format_when_compressing<'a>(formats: &'a [Extension], output_
 }
 
 /// Check if compression is invalid because an archive format is necessary.
+///
+/// Non-archive formats don't support multiple file compression or folder compression.
 pub fn check_invalid_compression_with_non_archive_format(
     formats: &[Extension],
     output_path: &Path,
@@ -180,46 +182,48 @@ pub fn check_invalid_compression_with_non_archive_format(
     let is_some_input_a_folder = files.iter().any(|path| path.is_dir());
     let is_multiple_inputs = files.len() > 1;
 
-    // If first format is not archive, can't compress folder, or multiple files
-    if !first_format.is_archive() && (is_some_input_a_folder || is_multiple_inputs) {
-        let first_detail_message = if is_multiple_inputs {
-            "You are trying to compress multiple files."
-        } else {
-            "You are trying to compress a folder."
-        };
-
-        let (from_hint, to_hint) = if let Some(formats) = formats_from_flag {
-            let formats = formats.to_string_lossy();
-            (
-                format!("From: --format {formats}"),
-                format!("To:   --format tar.{formats}"),
-            )
-        } else {
-            // This piece of code creates a suggestion for compressing multiple files
-            // It says:
-            // Change from file.bz.xz
-            // To          file.tar.bz.xz
-            let suggested_output_path = build_archive_file_suggestion(output_path, ".tar")
-                .expect("output path should contain a compression format");
-
-            (
-                format!("From: {}", EscapedPathDisplay::new(output_path)),
-                format!("To:   {suggested_output_path}"),
-            )
-        };
-        let output_path = EscapedPathDisplay::new(output_path);
-
-        let error = FinalError::with_title(format!("Cannot compress to '{output_path}'."))
-            .detail(first_detail_message)
-            .detail(format!(
-                "The compression format '{first_format}' does not accept multiple files.",
-            ))
-            .detail("Formats that bundle files into an archive are tar and zip.")
-            .hint(format!("Try inserting 'tar.' or 'zip.' before '{first_format}'."))
-            .hint(from_hint)
-            .hint(to_hint);
-
-        return Err(error.into());
+    // If format is archive, nothing to check
+    // If there's no folder or multiple inputs, non-archive formats can handle it
+    if first_format.is_archive() || !is_some_input_a_folder && !is_multiple_inputs {
+        return Ok(());
     }
-    Ok(())
+
+    let first_detail_message = if is_multiple_inputs {
+        "You are trying to compress multiple files."
+    } else {
+        "You are trying to compress a folder."
+    };
+
+    let (from_hint, to_hint) = if let Some(formats) = formats_from_flag {
+        let formats = formats.to_string_lossy();
+        (
+            format!("From: --format {formats}"),
+            format!("To:   --format tar.{formats}"),
+        )
+    } else {
+        // This piece of code creates a suggestion for compressing multiple files
+        // It says:
+        // Change from file.bz.xz
+        // To          file.tar.bz.xz
+        let suggested_output_path = build_archive_file_suggestion(output_path, ".tar")
+            .expect("output path should contain a compression format");
+
+        (
+            format!("From: {}", EscapedPathDisplay::new(output_path)),
+            format!("To:   {suggested_output_path}"),
+        )
+    };
+    let output_path = EscapedPathDisplay::new(output_path);
+
+    let error = FinalError::with_title(format!("Cannot compress to '{output_path}'."))
+        .detail(first_detail_message)
+        .detail(format!(
+            "The compression format '{first_format}' does not accept multiple files.",
+        ))
+        .detail("Formats that bundle files into an archive are tar and zip.")
+        .hint(format!("Try inserting 'tar.' or 'zip.' before '{first_format}'."))
+        .hint(from_hint)
+        .hint(to_hint);
+
+    Err(error.into())
 }

--- a/src/check.rs
+++ b/src/check.rs
@@ -1,3 +1,7 @@
+//! Checks for errors.
+
+#![warn(missing_docs)]
+
 use std::{
     ops::ControlFlow,
     path::{Path, PathBuf},
@@ -12,6 +16,12 @@ use crate::{
     warning, QuestionAction, QuestionPolicy, Result,
 };
 
+/// Check, for each file, if the mime type matches the detected extensions.
+///
+/// In case the file doesn't has any extensions, try to infer the format.
+///
+/// TODO: maybe the name of this should be "magic numbers" or "file signature",
+/// and not MIME.
 pub fn check_mime_type(
     files: &[PathBuf],
     formats: &mut [Vec<Extension>],
@@ -87,6 +97,7 @@ pub fn check_for_non_archive_formats(files: &[PathBuf], formats: &[Vec<Extension
     Ok(())
 }
 
+/// Show error if archive format is not the first format in the chain.
 pub fn check_archive_formats_position(formats: &[extension::Extension], output_path: &Path) -> Result<()> {
     if let Some(format) = formats.iter().skip(1).find(|format| format.is_archive()) {
         let error = FinalError::with_title(format!(

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -12,7 +12,7 @@ use clap::{Parser, ValueHint};
 #[command(about, version)]
 // Disable rustdoc::bare_urls because rustdoc parses URLs differently than Clap
 #[allow(rustdoc::bare_urls)]
-pub struct Opts {
+pub struct CliArgs {
     /// Skip [Y/n] questions positively
     #[arg(short, long, conflicts_with = "no", global = true)]
     pub yes: bool,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -5,7 +5,7 @@ use clap::{Parser, ValueHint};
 // Ouch command line options (docstrings below are part of --help)
 /// A command-line utility for easily compressing and decompressing files and directories.
 ///
-/// Supported formats: tar, zip, bz/bz2, gz, lz4, xz/lzma, zst.
+/// Supported formats: tar, zip, gz, xz/lzma, bz/bz2, lz4, sz, zst.
 ///
 /// Repository: https://github.com/ouch-org/ouch
 #[derive(Parser, Debug)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,6 @@
-//! CLI related functions, uses the clap argparsing definitions from `opts.rs`.
+//! CLI related functions, uses the clap argparsing definitions from `args.rs`.
+
+mod args;
 
 use std::{
     io,
@@ -9,25 +11,26 @@ use std::{
 use clap::Parser;
 use fs_err as fs;
 
-use crate::{accessible::set_accessible, utils::FileVisibilityPolicy, Opts, QuestionPolicy, Subcommand};
+pub use self::args::{CliArgs, Subcommand};
+use crate::{accessible::set_accessible, utils::FileVisibilityPolicy, QuestionPolicy};
 
-impl Opts {
+impl CliArgs {
     /// A helper method that calls `clap::Parser::parse`.
     ///
     /// And:
     ///   1. Make paths absolute.
     ///   2. Checks the QuestionPolicy.
     pub fn parse_args() -> crate::Result<(Self, QuestionPolicy, FileVisibilityPolicy)> {
-        let mut opts = Self::parse();
+        let mut args = Self::parse();
 
-        set_accessible(opts.accessible);
+        set_accessible(args.accessible);
 
         let (Subcommand::Compress { files, .. }
         | Subcommand::Decompress { files, .. }
-        | Subcommand::List { archives: files, .. }) = &mut opts.cmd;
+        | Subcommand::List { archives: files, .. }) = &mut args.cmd;
         *files = canonicalize_files(files)?;
 
-        let skip_questions_positively = match (opts.yes, opts.no) {
+        let skip_questions_positively = match (args.yes, args.no) {
             (false, false) => QuestionPolicy::Ask,
             (true, false) => QuestionPolicy::AlwaysYes,
             (false, true) => QuestionPolicy::AlwaysNo,
@@ -35,12 +38,12 @@ impl Opts {
         };
 
         let file_visibility_policy = FileVisibilityPolicy::new()
-            .read_git_exclude(opts.gitignore)
-            .read_ignore(opts.gitignore)
-            .read_git_ignore(opts.gitignore)
-            .read_hidden(opts.hidden);
+            .read_git_exclude(args.gitignore)
+            .read_ignore(args.gitignore)
+            .read_git_ignore(args.gitignore)
+            .read_hidden(args.hidden);
 
-        Ok((opts, skip_questions_positively, file_visibility_policy))
+        Ok((args, skip_questions_positively, file_visibility_policy))
     }
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -13,6 +13,7 @@ use rayon::prelude::{IndexedParallelIterator, IntoParallelRefIterator, ParallelI
 use utils::colors;
 
 use crate::{
+    cli::{CliArgs, Subcommand},
     commands::{compress::compress_files, decompress::decompress_file, list::list_archive_contents},
     error::{Error, FinalError},
     extension::{self, flatten_compression_formats, parse_format, Extension, SUPPORTED_EXTENSIONS},
@@ -22,7 +23,7 @@ use crate::{
         self, pretty_format_list_of_paths, to_utf, try_infer_extension, user_wants_to_continue, EscapedPathDisplay,
         FileVisibilityPolicy,
     },
-    warning, Opts, QuestionAction, QuestionPolicy, Subcommand,
+    warning, QuestionAction, QuestionPolicy,
 };
 
 /// Warn the user that (de)compressing this .zip archive might freeze their system.
@@ -99,7 +100,7 @@ fn check_for_non_archive_formats(files: &[PathBuf], formats: &[Vec<Extension>]) 
 ///
 /// There are a lot of custom errors to give enough error description and explanation.
 pub fn run(
-    args: Opts,
+    args: CliArgs,
     question_policy: QuestionPolicy,
     file_visibility_policy: FileVisibilityPolicy,
 ) -> crate::Result<()> {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -10,7 +10,7 @@ use rayon::prelude::{IndexedParallelIterator, IntoParallelRefIterator, ParallelI
 use utils::colors;
 
 use crate::{
-    check::{check_for_non_archive_formats, check_mime_type},
+    check::{check_archive_formats_position, check_for_non_archive_formats, check_mime_type},
     cli::Subcommand,
     commands::{compress::compress_files, decompress::decompress_file, list::list_archive_contents},
     error::{Error, FinalError},
@@ -117,26 +117,7 @@ pub fn run(
                 return Err(error.into());
             }
 
-            if let Some(format) = formats.iter().skip(1).find(|format| format.is_archive()) {
-                let error = FinalError::with_title(format!(
-                    "Cannot compress to '{}'.",
-                    EscapedPathDisplay::new(&output_path)
-                ))
-                .detail(format!("Found the format '{format}' in an incorrect position."))
-                .detail(format!(
-                    "'{format}' can only be used at the start of the file extension."
-                ))
-                .hint(format!(
-                    "If you wish to compress multiple files, start the extension with '{format}'."
-                ))
-                .hint(format!(
-                    "Otherwise, remove the last '{}' from '{}'.",
-                    format,
-                    EscapedPathDisplay::new(&output_path)
-                ));
-
-                return Err(error.into());
-            }
+            check_archive_formats_position(&formats, &output_path)?;
 
             let output_file = match utils::ask_to_create_file(&output_path, question_policy)? {
                 Some(writer) => writer,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -59,17 +59,7 @@ pub fn run(
                 None => (None, extension::extensions_from_path(&output_path)),
             };
 
-            let first_format = formats.first().ok_or_else(|| {
-                let output_path = EscapedPathDisplay::new(&output_path);
-                FinalError::with_title(format!("Cannot compress to '{output_path}'."))
-                    .detail("You shall supply the compression format")
-                    .hint("Try adding supported extensions (see --help):")
-                    .hint(format!("  ouch compress <FILES>... {output_path}.tar.gz"))
-                    .hint(format!("  ouch compress <FILES>... {output_path}.zip"))
-                    .hint("")
-                    .hint("Alternatively, you can overwrite this option by using the '--format' flag:")
-                    .hint(format!("  ouch compress <FILES>... {output_path} --format tar.gz"))
-            })?;
+            let first_format = check::check_first_format_when_compressing(&formats, &output_path)?;
 
             let is_some_input_a_folder = files.iter().any(|path| path.is_dir());
             let is_multiple_inputs = files.len() > 1;

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -170,6 +170,21 @@ pub fn extensions_from_path(path: &Path) -> Vec<Extension> {
     extensions
 }
 
+// Panics if formats has an empty list of compression formats
+pub fn split_first_compression_format(formats: &[Extension]) -> (CompressionFormat, Vec<CompressionFormat>) {
+    let mut extensions: Vec<CompressionFormat> = flatten_compression_formats(formats);
+    let first_extension = extensions.remove(0);
+    (first_extension, extensions)
+}
+
+pub fn flatten_compression_formats(extensions: &[Extension]) -> Vec<CompressionFormat> {
+    extensions
+        .iter()
+        .flat_map(|extension| extension.compression_formats.iter())
+        .copied()
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -184,19 +199,4 @@ mod tests {
 
         assert_eq!(formats, vec![Tar, Gzip]);
     }
-}
-
-// Panics if formats has an empty list of compression formats
-pub fn split_first_compression_format(formats: &[Extension]) -> (CompressionFormat, Vec<CompressionFormat>) {
-    let mut extensions: Vec<CompressionFormat> = flatten_compression_formats(formats);
-    let first_extension = extensions.remove(0);
-    (first_extension, extensions)
-}
-
-pub fn flatten_compression_formats(extensions: &[Extension]) -> Vec<CompressionFormat> {
-    extensions
-        .iter()
-        .flat_map(|extension| extension.compression_formats.iter())
-        .copied()
-        .collect()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,14 +10,11 @@ pub mod extension;
 pub mod list;
 pub mod utils;
 
-/// CLI argparsing definitions, using `clap`.
-pub mod opts;
-
 use std::{env, path::PathBuf};
 
+use cli::CliArgs;
 use error::{Error, Result};
 use once_cell::sync::Lazy;
-use opts::{Opts, Subcommand};
 use utils::{QuestionAction, QuestionPolicy};
 
 // Used in BufReader and BufWriter to perform less syscalls
@@ -37,6 +34,6 @@ fn main() {
 }
 
 fn run() -> Result<()> {
-    let (args, skip_questions_positively, file_visibility_policy) = Opts::parse_args()?;
+    let (args, skip_questions_positively, file_visibility_policy) = CliArgs::parse_args()?;
     commands::run(args, skip_questions_positively, file_visibility_policy)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ pub mod macros;
 
 pub mod accessible;
 pub mod archive;
+pub mod check;
 pub mod cli;
 pub mod commands;
 pub mod error;

--- a/src/utils/formatting.rs
+++ b/src/utils/formatting.rs
@@ -62,7 +62,7 @@ pub fn strip_cur_dir(source_path: &Path) -> &Path {
     source_path.strip_prefix(current_dir).unwrap_or(source_path)
 }
 
-/// Converts a slice of AsRef<OsStr> to comma separated String
+/// Converts a slice of `AsRef<OsStr>` to comma separated String
 ///
 /// Panics if the slice is empty.
 pub fn pretty_format_list_of_paths(os_strs: &[impl AsRef<Path>]) -> String {


### PR DESCRIPTION
This is an attempt of separating the messy error treatment code
from the `run` function, because it was too large.

The new file `check.rs` contains the important usage checks that
are done in runtime.
