### PR TITLE
tests: reduce maximum compression level

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -103,7 +103,7 @@ fn single_empty_file(ext: Extension, #[any(size_range(0..8).lift())] exts: Vec<F
 fn single_file(
     ext: Extension,
     #[any(size_range(0..8).lift())] exts: Vec<FileExtension>,
-    #[strategy(proptest::option::of(0i16..30))] level: Option<i16>,
+    #[strategy(proptest::option::of(0i16..12))] level: Option<i16>,
 ) {
     let dir = tempdir().unwrap();
     let dir = dir.path();


### PR DESCRIPTION
<!--
Make sure to check out CONTRIBUTING.md.
Don't forget to add a CHANGELOG.md entry!
-->

CI sometimes runs out of memory on cross, this should ease the issue a bit