### PR TITLE
switch to lz4_flex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,6 +686,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad6f50e0fd4351da4b429de1234c28feda97aafa5748fbd4a74634f5cc5d82dd"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "lzma-sys"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,15 +703,6 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
-]
-
-[[package]]
-name = "lzzzz"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8014d1362004776e6a91e4c15a3aa7830d1b6650a075b51a9969ebb6d6af13bc"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -784,7 +784,7 @@ dependencies = [
  "is_executable",
  "libc",
  "linked-hash-map",
- "lzzzz",
+ "lz4_flex",
  "once_cell",
  "parse-display",
  "proptest",
@@ -1117,6 +1117,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1255,6 +1261,16 @@ name = "time-core"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
+]
 
 [[package]]
 name = "ubyte"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ gzp = { version = "0.11.3", default-features = false, features = ["snappy_defaul
 ignore = "0.4.20"
 libc = "0.2.146"
 linked-hash-map = "0.5.6"
-lzzzz = "1.0.4"
+lz4_flex = "0.11.0"
 once_cell = "1.18.0"
 rayon = "1.7.0"
 same-file = "1.0.6"

--- a/src/commands/compress.rs
+++ b/src/commands/compress.rs
@@ -55,12 +55,7 @@ pub fn compress_files(
                 encoder,
                 level.map_or_else(Default::default, |l| bzip2::Compression::new((l as u32).clamp(1, 9))),
             )),
-            Lz4 => Box::new(lzzzz::lz4f::WriteCompressor::new(
-                encoder,
-                lzzzz::lz4f::PreferencesBuilder::new()
-                    .compression_level(level.map_or(1, |l| (l as i32).clamp(1, lzzzz::lz4f::CLEVEL_MAX)))
-                    .build(),
-            )?),
+            Lz4 => Box::new(lz4_flex::frame::FrameEncoder::new(encoder).auto_finish()),
             Lzma => Box::new(xz2::write::XzEncoder::new(
                 encoder,
                 level.map_or(6, |l| (l as u32).clamp(0, 9)),

--- a/src/commands/decompress.rs
+++ b/src/commands/decompress.rs
@@ -82,7 +82,7 @@ pub fn decompress_file(
         let decoder: Box<dyn Read> = match format {
             Gzip => Box::new(flate2::read::GzDecoder::new(decoder)),
             Bzip => Box::new(bzip2::read::BzDecoder::new(decoder)),
-            Lz4 => Box::new(lzzzz::lz4f::ReadDecompressor::new(decoder)?),
+            Lz4 => Box::new(lz4_flex::frame::FrameDecoder::new(decoder)),
             Lzma => Box::new(xz2::read::XzDecoder::new(decoder)),
             Snappy => Box::new(snap::read::FrameDecoder::new(decoder)),
             Zstd => Box::new(zstd::stream::Decoder::new(decoder)?),

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -48,7 +48,7 @@ pub fn list_archive_contents(
             let decoder: Box<dyn Read + Send> = match format {
                 Gzip => Box::new(flate2::read::GzDecoder::new(decoder)),
                 Bzip => Box::new(bzip2::read::BzDecoder::new(decoder)),
-                Lz4 => Box::new(lzzzz::lz4f::ReadDecompressor::new(decoder)?),
+                Lz4 => Box::new(lz4_flex::frame::FrameDecoder::new(decoder)),
                 Lzma => Box::new(xz2::read::XzDecoder::new(decoder)),
                 Snappy => Box::new(snap::read::FrameDecoder::new(decoder)),
                 Zstd => Box::new(zstd::stream::Decoder::new(decoder)?),

--- a/src/error.rs
+++ b/src/error.rs
@@ -164,14 +164,6 @@ impl From<std::io::Error> for Error {
     }
 }
 
-impl From<lzzzz::lz4f::Error> for Error {
-    fn from(err: lzzzz::lz4f::Error) -> Self {
-        Self::Lz4Error {
-            reason: err.to_string(),
-        }
-    }
-}
-
 impl From<zip::result::ZipError> for Error {
     fn from(err: zip::result::ZipError) -> Self {
         use zip::result::ZipError;


### PR DESCRIPTION
The release of lz4_flex 0.11 fixes two issue that caused problems
before:
- The new `auto-finish` flushes on drop
- FrameEncoder writes now empty frames. Previously nothing was written,
  which caused issues with double compressed empty data.

