### PR TITLE
Strip binary when building with cargo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,4 @@ default = ["flate2/zlib", "gzp/deflate_zlib", "zip/deflate-zlib", "zstd/thin"]
 lto = true
 codegen-units = 1
 opt-level = 3
+strip = true


### PR DESCRIPTION
This is already done in CI, but with this PR, running
`cargo build` or `cargo install` will also do it for you.