### PR TITLE
README + help: Clarify that .sz refers to Google's Snappy format, mention 7z support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ Output:
 
 # Supported formats
 
-| Format    | `.tar` | `.zip` | `.gz` | `.xz`, `.lzma` | `.bz`, `.bz2` | `.lz4` | `.sz` (Snappy) | `.zst` |
-|:---------:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| Supported | ✓ | ✓¹ | ✓² | ✓ | ✓ | ✓ | ✓² | ✓ |
+| Format    | `.tar` | `.zip` | `7z` | `.gz` | `.xz`, `.lzma` | `.bz`, `.bz2` | `.lz4` | `.sz` (Snappy) | `.zst` |
+|:---------:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| Supported | ✓ | ✓¹ | ✓ | ✓² | ✓ | ✓ | ✓ | ✓² | ✓ |
 
 ✓: Supports compression and decompression.
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Output:
 
 # Supported formats
 
-| Format    | `.tar` | `.zip` | `.gz` | `.xz`, `.lzma` | `.bz`, `.bz2` | `.lz4` | `.sz` | `.zst` |
+| Format    | `.tar` | `.zip` | `.gz` | `.xz`, `.lzma` | `.bz`, `.bz2` | `.lz4` | `.sz` (Snappy) | `.zst` |
 |:---------:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | Supported | ✓ | ✓¹ | ✓² | ✓ | ✓ | ✓ | ✓² | ✓ |
 

--- a/README.md
+++ b/README.md
@@ -111,25 +111,26 @@ Output:
 
 # Supported formats
 
-| Format    | `.tar` | `.zip` | `7z` | `.gz` | `.xz`, `.lzma` | `.bz`, `.bz2` | `.lz4` | `.sz` (Snappy) | `.zst` |
-|:---------:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| Supported | ✓ | ✓¹ | ✓ | ✓² | ✓ | ✓ | ✓ | ✓² | ✓ |
+| Format    | `.tar` | `.zip` | `7z` | `.gz` | `.xz`, `.lzma` | `.bz`, `.bz2` | `.lz4` | `.sz` (Snappy) | `.zst` | `.rar` |
+|:---------:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| Supported | ✓ | ✓¹ | ✓¹ | ✓² | ✓ | ✓ | ✓ | ✓² | ✓ | ✓³ |
 
 ✓: Supports compression and decompression.
 
-✓¹: Due to limitations of `.zip`, it doesn't support streaming (de)compression.
+✓¹: Due to limitations of the compression format itself, (de)compression can't be done with streaming.
 
 ✓²: Supported, and compression runs in parallel.
+
+✓³: Due to Rar's restrictive license, only decompression and listing can be supported.
 
 `tar` aliases are also supported: `tgz`, `tbz`, `tbz2`, `tlz4`, `txz`, `tlzma`, `tsz`, `tzst`.
 
 Formats can be chained:
 
-- `.zst.gz`
-- `.tar.gz.gz`
-- `.tar.gz.gz.gz.zst.xz.bz.lz4`
+- `.tar.gz`
+- `.tar.gz.xz.zst.gz.lz4.sz`
 
-If the filename has no extensions, `Ouch` will try to infer the format by the [file signature](https://en.wikipedia.org/wiki/List_of_file_signatures).
+If the filename has no extensions, `Ouch` will try to infer the format by the [file signature](https://en.wikipedia.org/wiki/List_of_file_signatures) and ask the user for confirmation.
 
 # Installation
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -5,7 +5,7 @@ use clap::{Parser, ValueHint};
 // Ouch command line options (docstrings below are part of --help)
 /// A command-line utility for easily compressing and decompressing files and directories.
 ///
-/// Supported formats: tar, zip, gz, xz/lzma, bz/bz2, lz4, sz (Snappy), zst.
+/// Supported formats: tar, zip, gz, 7z, xz/lzma, bz/bz2, lz4, sz (Snappy), zst.
 ///
 /// Repository: https://github.com/ouch-org/ouch
 #[derive(Parser, Debug, PartialEq)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -5,7 +5,7 @@ use clap::{Parser, ValueHint};
 // Ouch command line options (docstrings below are part of --help)
 /// A command-line utility for easily compressing and decompressing files and directories.
 ///
-/// Supported formats: tar, zip, gz, xz/lzma, bz/bz2, lz4, sz, zst.
+/// Supported formats: tar, zip, gz, xz/lzma, bz/bz2, lz4, sz (Snappy), zst.
 ///
 /// Repository: https://github.com/ouch-org/ouch
 #[derive(Parser, Debug, PartialEq)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -5,7 +5,7 @@ use clap::{Parser, ValueHint};
 // Ouch command line options (docstrings below are part of --help)
 /// A command-line utility for easily compressing and decompressing files and directories.
 ///
-/// Supported formats: tar, zip, gz, 7z, xz/lzma, bz/bz2, lz4, sz (Snappy), zst.
+/// Supported formats: tar, zip, gz, 7z, xz/lzma, bz/bz2, lz4, sz (Snappy), zst and rar.
 ///
 /// Repository: https://github.com/ouch-org/ouch
 #[derive(Parser, Debug, PartialEq)]

--- a/tests/snapshots/ui__ui_test_usage_help_flag.snap
+++ b/tests/snapshots/ui__ui_test_usage_help_flag.snap
@@ -4,7 +4,7 @@ expression: "output_to_string(ouch!(\"--help\"))"
 ---
 A command-line utility for easily compressing and decompressing files and directories.
 
-Supported formats: tar, zip, gz, xz/lzma, bz/bz2, lz4, sz (Snappy), zst.
+Supported formats: tar, zip, gz, 7z, xz/lzma, bz/bz2, lz4, sz (Snappy), zst.
 
 Repository: https://github.com/ouch-org/ouch
 

--- a/tests/snapshots/ui__ui_test_usage_help_flag.snap
+++ b/tests/snapshots/ui__ui_test_usage_help_flag.snap
@@ -4,7 +4,7 @@ expression: "output_to_string(ouch!(\"--help\"))"
 ---
 A command-line utility for easily compressing and decompressing files and directories.
 
-Supported formats: tar, zip, gz, xz/lzma, bz/bz2, lz4, sz, zst.
+Supported formats: tar, zip, gz, xz/lzma, bz/bz2, lz4, sz (Snappy), zst.
 
 Repository: https://github.com/ouch-org/ouch
 

--- a/tests/snapshots/ui__ui_test_usage_help_flag.snap
+++ b/tests/snapshots/ui__ui_test_usage_help_flag.snap
@@ -4,7 +4,7 @@ expression: "output_to_string(ouch!(\"--help\"))"
 ---
 A command-line utility for easily compressing and decompressing files and directories.
 
-Supported formats: tar, zip, gz, 7z, xz/lzma, bz/bz2, lz4, sz (Snappy), zst.
+Supported formats: tar, zip, gz, 7z, xz/lzma, bz/bz2, lz4, sz (Snappy), zst and rar.
 
 Repository: https://github.com/ouch-org/ouch
 


### PR DESCRIPTION
It needs to be disambiguated from the unfortunately named SZ compression, see https://szcompressor.org/.

Since I was working on relevant strings, I also added 7z in the same places. I did not add RAR because of #565 and not to interfere with #566.

Fixes #563