### PR TITLE
CI refactor

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,51 +17,48 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+          - x86_64-pc-windows-gnu
+          - x86_64-pc-windows-msvc
+          - x86_64-apple-darwin
+          - aarch64-unknown-linux-gnu
+          - aarch64-unknown-linux-musl
+          - armv7-unknown-linux-gnueabihf
+          - armv7-unknown-linux-musleabihf
+          - aarch64-pc-windows-msvc
+        feature-use-zlib: [true, false]
+        feature-use-zstd-thin: [true, false]
+
         include:
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
-            no-zstd-thin: true
-
-          - target: aarch64-unknown-linux-musl
-            os: ubuntu-latest
-            no-zstd-thin: true
-
-          - target: armv7-unknown-linux-gnueabihf
-            os: ubuntu-latest
-            no-zstd-thin: true
-
-          - target: armv7-unknown-linux-musleabihf
-            os: ubuntu-latest
-            no-zstd-thin: true
-
-          - target: x86_64-apple-darwin
-            os: macos-latest
-
+          # default runner
+          - os: ubuntu-latest
+          # runner overrides
           - target: x86_64-pc-windows-gnu
             os: windows-latest
-            no-zstd-thin: true
-            ext: .exe
-
           - target: x86_64-pc-windows-msvc
             os: windows-latest
-            ext: .exe
-
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          # targets that require cross
+          - target: aarch64-unknown-linux-gnu
+            use-cross: true
+          - target: aarch64-unknown-linux-musl
+            use-cross: true
+          - target: armv7-unknown-linux-gnueabihf
+            use-cross: true
+          - target: armv7-unknown-linux-musleabihf
+            use-cross: true
           - target: aarch64-pc-windows-msvc
-            os: windows-latest
-            ext: .exe
-
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
-
-          - target: x86_64-unknown-linux-musl
-            os: ubuntu-latest
+            use-cross: true
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install cross (non-x86_64 linux)
-        if: matrix.target != 'x86_64-unknown-linux-gnu' && runner.os == 'Linux'
+      - name: Install cross
+        if: matrix.use-cross
         run: |
           pushd "$(mktemp -d)"
           wget https://github.com/cross-rs/cross/releases/download/v0.2.4/cross-x86_64-unknown-linux-musl.tar.gz
@@ -70,10 +67,24 @@ jobs:
           popd
           echo CARGO=cross >> $GITHUB_ENV
 
-      - name: Set up extra cargo flags
-        if: matrix.no-zstd-thin
+      - name: Concatenate features
+        id: concat-features
+        shell: bash
         run: |
-          echo "EXTRA_CARGO_FLAGS=--no-default-features --features use_zlib" >> $GITHUB_ENV
+          FEATURES=()
+          if [[ ${{ matrix.feature-use-zlib }} == true ]]; then FEATURES+=(use_zlib); fi
+          if [[ ${{ matrix.feature-use-zstd-thin }} == true ]]; then FEATURES+=(use_zstd_thin); fi
+          IFS=','
+          echo "FEATURES=${FEATURES[*]}" >> $GITHUB_OUTPUT
+
+      - name: Set up extra cargo flags
+        env:
+          FEATURES: ${{steps.concat-features.outputs.FEATURES}}
+        shell: bash
+        run: |
+          FLAGS="--no-default-features"
+          if [[ -n "$FEATURES" ]]; then FLAGS+=" --features $FEATURES"; fi
+          echo "EXTRA_CARGO_FLAGS=$FLAGS" >> $GITHUB_ENV
 
       - name: Install Rust
         run: |
@@ -93,9 +104,10 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: ouch-${{ matrix.target }}${{ matrix.ext }}
+          name: ouch-${{ matrix.target }}-${{ steps.concat-features.outputs.FEATURES }}
           path: |
-            target/${{ matrix.target }}/release/ouch${{ matrix.ext }}
+            target/${{ matrix.target }}/release/ouch
+            target/${{ matrix.target }}/release/ouch.exe
             artifacts/
 
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,16 +18,18 @@ jobs:
       fail-fast: false
       matrix:
         target:
+          # native
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl
           - x86_64-pc-windows-gnu
           - x86_64-pc-windows-msvc
+          - aarch64-pc-windows-msvc
           - x86_64-apple-darwin
+          # cross
           - aarch64-unknown-linux-gnu
           - aarch64-unknown-linux-musl
           - armv7-unknown-linux-gnueabihf
           - armv7-unknown-linux-musleabihf
-          - aarch64-pc-windows-msvc
         feature-use-zlib: [true, false]
         feature-use-zstd-thin: [true, false]
 
@@ -39,6 +41,8 @@ jobs:
             os: windows-latest
           - target: x86_64-pc-windows-msvc
             os: windows-latest
+          - target: aarch64-pc-windows-msvc
+            os: windows-latest
           - target: x86_64-apple-darwin
             os: macos-latest
           # targets that require cross
@@ -49,8 +53,6 @@ jobs:
           - target: armv7-unknown-linux-gnueabihf
             use-cross: true
           - target: armv7-unknown-linux-musleabihf
-            use-cross: true
-          - target: aarch64-pc-windows-msvc
             use-cross: true
 
     steps:
@@ -91,6 +93,8 @@ jobs:
           rustup toolchain install stable nightly --profile minimal -t ${{ matrix.target }}
 
       - name: Test on stable
+        # there's no way to run tests for ARM64 Windows for now
+        if: matrix.target != 'aarch64-pc-windows-msvc'
         run: |
           ${{ env.CARGO }} +stable test --target ${{ matrix.target }} $EXTRA_CARGO_FLAGS
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,7 +48,6 @@ jobs:
           - target: aarch64-pc-windows-msvc
             os: windows-latest
             ext: .exe
-            skip-test: true
 
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
@@ -80,7 +79,6 @@ jobs:
           rustup toolchain install stable nightly --profile minimal -t ${{ matrix.target }}
 
       - name: Test on stable
-        if: ${{ ! matrix.skip-test }}
         run: |
           ${{ env.CARGO }} +stable test --target ${{ matrix.target }} $EXTRA_CARGO_FLAGS
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       CARGO: cargo
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: aarch64-unknown-linux-gnu

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,12 +20,12 @@ jobs:
         target:
           # native
           - x86_64-unknown-linux-gnu
-          - x86_64-unknown-linux-musl
           - x86_64-pc-windows-gnu
           - x86_64-pc-windows-msvc
           - aarch64-pc-windows-msvc
           - x86_64-apple-darwin
           # cross
+          - x86_64-unknown-linux-musl
           - aarch64-unknown-linux-gnu
           - aarch64-unknown-linux-musl
           - armv7-unknown-linux-gnueabihf
@@ -45,7 +45,9 @@ jobs:
             os: windows-latest
           - target: x86_64-apple-darwin
             os: macos-latest
-          # targets that require cross
+          # targets that use cross
+          - target: x86_64-unknown-linux-musl
+            use-cross: true
           - target: aarch64-unknown-linux-gnu
             use-cross: true
           - target: aarch64-unknown-linux-musl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Categories Used:
 
 ### Tweaks
 
+- CI refactor [\#578](https://github.com/ouch-org/ouch/pull/578) ([cyqsimon](https://github.com/cyqsimon))
+
 ### Improvements
 
 ## [0.5.1](https://github.com/ouch-org/ouch/compare/0.5.0...0.5.1)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,6 +613,7 @@ dependencies = [
  "console",
  "lazy_static",
  "linked-hash-map",
+ "regex",
  "similar",
  "yaml-rust",
 ]
@@ -842,6 +843,7 @@ dependencies = [
  "proptest",
  "rand",
  "rayon",
+ "regex",
  "same-file",
  "sevenz-rust",
  "snap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,10 +47,11 @@ clap_mangen = "0.2.15"
 [dev-dependencies]
 assert_cmd = "2.0.12"
 infer = "0.15.0"
-insta = "1.34.0"
+insta = { version = "1.34.0", features = ["filters"] }
 parse-display = "0.8.2"
 proptest = "1.4.0"
 rand = { version = "0.8.5", default-features = false, features = ["small_rng", "std"] }
+regex = "1.10.2"
 test-strategy = "0.3.1"
 
 [features]

--- a/tests/snapshots/ui__ui_test_err_decompress_missing_extension-2.snap
+++ b/tests/snapshots/ui__ui_test_err_decompress_missing_extension-2.snap
@@ -3,8 +3,8 @@ source: tests/ui.rs
 expression: "run_ouch(\"ouch decompress a b.unknown\", dir)"
 ---
 [ERROR] Cannot decompress files
- - Files with unsupported extensions: <FOLDER>/b.unknown
- - Files with missing extensions: <FOLDER>/a
+ - Files with unsupported extensions: <TMP_DIR>/b.unknown
+ - Files with missing extensions: <TMP_DIR>/a
  - Decompression formats are detected automatically from file extension
 
 hint: Supported extensions are: tar, zip, bz, bz2, gz, lz4, xz, lzma, sz, zst, rar

--- a/tests/snapshots/ui__ui_test_err_decompress_missing_extension-3.snap
+++ b/tests/snapshots/ui__ui_test_err_decompress_missing_extension-3.snap
@@ -3,12 +3,12 @@ source: tests/ui.rs
 expression: "run_ouch(\"ouch decompress b.unknown\", dir)"
 ---
 [ERROR] Cannot decompress files
- - Files with unsupported extensions: <FOLDER>/b.unknown
+ - Files with unsupported extensions: <TMP_DIR>/b.unknown
  - Decompression formats are detected automatically from file extension
 
 hint: Supported extensions are: tar, zip, bz, bz2, gz, lz4, xz, lzma, sz, zst, rar
 hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst
 hint: 
 hint: Alternatively, you can pass an extension to the '--format' flag:
-hint:   ouch decompress <FOLDER>/b.unknown --format tar.gz
+hint:   ouch decompress <TMP_DIR>/b.unknown --format tar.gz
 

--- a/tests/snapshots/ui__ui_test_err_decompress_missing_extension.snap
+++ b/tests/snapshots/ui__ui_test_err_decompress_missing_extension.snap
@@ -3,12 +3,12 @@ source: tests/ui.rs
 expression: "run_ouch(\"ouch decompress a\", dir)"
 ---
 [ERROR] Cannot decompress files
- - Files with missing extensions: <FOLDER>/a
+ - Files with missing extensions: <TMP_DIR>/a
  - Decompression formats are detected automatically from file extension
 
 hint: Supported extensions are: tar, zip, bz, bz2, gz, lz4, xz, lzma, sz, zst, rar
 hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst
 hint: 
 hint: Alternatively, you can pass an extension to the '--format' flag:
-hint:   ouch decompress <FOLDER>/a --format tar.gz
+hint:   ouch decompress <TMP_DIR>/a --format tar.gz
 

--- a/tests/snapshots/ui__ui_test_usage_help_flag-2.snap
+++ b/tests/snapshots/ui__ui_test_usage_help_flag-2.snap
@@ -4,7 +4,7 @@ expression: "output_to_string(ouch!(\"-h\"))"
 ---
 A command-line utility for easily compressing and decompressing files and directories.
 
-Usage: ouch [OPTIONS] <COMMAND>
+Usage: <OUCH_BIN> [OPTIONS] <COMMAND>
 
 Commands:
   compress    Compress one or more files into one output file [aliases: c]

--- a/tests/snapshots/ui__ui_test_usage_help_flag.snap
+++ b/tests/snapshots/ui__ui_test_usage_help_flag.snap
@@ -8,7 +8,7 @@ Supported formats: tar, zip, gz, 7z, xz/lzma, bz/bz2, lz4, sz (Snappy), zst and 
 
 Repository: https://github.com/ouch-org/ouch
 
-Usage: ouch [OPTIONS] <COMMAND>
+Usage: <OUCH_BIN> [OPTIONS] <COMMAND>
 
 Commands:
   compress    Compress one or more files into one output file [aliases: c]

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -8,12 +8,8 @@ mod utils;
 
 use std::{io, path::Path, process::Output};
 
-#[cfg(not(windows))]
 use insta::assert_display_snapshot as ui;
 
-// Don't run these on Windows
-#[cfg(windows)]
-use self::ignore as ui;
 use crate::utils::run_in;
 
 fn testdir() -> io::Result<(tempfile::TempDir, &'static Path)> {
@@ -113,12 +109,4 @@ fn ui_test_ok_decompress() {
 fn ui_test_usage_help_flag() {
     ui!(output_to_string(ouch!("--help")));
     ui!(output_to_string(ouch!("-h")));
-}
-
-#[allow(unused)]
-#[macro_export]
-macro_rules! ignore {
-    ($expr:expr) => {{
-        $expr
-    }};
 }


### PR DESCRIPTION
This is in preparation for #566. I thought I'd split it into two PRs for cleanliness.

## Main changes

- Tests are now enabled for all targets
  - String replacements/redactions have been configured where appropriate to ensure identical output
- Build and test is now happening for every possible feature combination on all targets
  - Except for `aarch64-pc-windows-msvc`, where tests are skipped because no runner is available