### PR TITLE
Add `zstd` (and `tzstd`) alias

### DIFF
--- a/src/extension.rs
+++ b/src/extension.rs
@@ -23,14 +23,14 @@ pub const SUPPORTED_EXTENSIONS: &[&str] = &[
     "7z",
 ];
 
-pub const SUPPORTED_ALIASES: &[&str] = &["tgz", "tbz", "tlz4", "txz", "tzlma", "tsz", "tzst"];
+pub const SUPPORTED_ALIASES: &[&str] = &["tgz", "tbz", "tlz4", "txz", "tzlma", "tsz", "tzst", "zstd", "tzstd"];
 
 #[cfg(not(feature = "unrar"))]
 pub const PRETTY_SUPPORTED_EXTENSIONS: &str = "tar, zip, bz, bz2, gz, lz4, xz, lzma, sz, zst, 7z";
 #[cfg(feature = "unrar")]
 pub const PRETTY_SUPPORTED_EXTENSIONS: &str = "tar, zip, bz, bz2, gz, lz4, xz, lzma, sz, zst, rar, 7z";
 
-pub const PRETTY_SUPPORTED_ALIASES: &str = "tgz, tbz, tlz4, txz, tzlma, tsz, tzst";
+pub const PRETTY_SUPPORTED_ALIASES: &str = "tgz, tbz, tlz4, txz, tzlma, tsz, tzst, zstd, tzstd";
 
 /// A wrapper around `CompressionFormat` that allows combinations like `tgz`
 #[derive(Debug, Clone, Eq)]
@@ -86,7 +86,7 @@ pub enum CompressionFormat {
     Lzma,
     /// .sz
     Snappy,
-    /// tar, tgz, tbz, tbz2, txz, tlz4, tlzma, tsz, tzst
+    /// tar, tgz, tbz, tbz2, txz, tlz4, tlzma, tsz, tzst, tzstd
     Tar,
     /// .zst
     Zstd,
@@ -124,14 +124,14 @@ fn to_extension(ext: &[u8]) -> Option<Extension> {
             b"tlz4" => &[Tar, Lz4],
             b"txz" | b"tlzma" => &[Tar, Lzma],
             b"tsz" => &[Tar, Snappy],
-            b"tzst" => &[Tar, Zstd],
+            b"tzst" | b"tzstd" => &[Tar, Zstd],
             b"zip" => &[Zip],
             b"bz" | b"bz2" => &[Bzip],
             b"gz" => &[Gzip],
             b"lz4" => &[Lz4],
             b"xz" | b"lzma" => &[Lzma],
             b"sz" => &[Snappy],
-            b"zst" => &[Zstd],
+            b"zst" | b"zstd" => &[Zstd],
             b"rar" => &[Rar],
             b"7z" => &[SevenZip],
             _ => return None,

--- a/tests/mime.rs
+++ b/tests/mime.rs
@@ -17,7 +17,7 @@ fn sanity_check_through_mime() {
     write_random_content(test_file, &mut SmallRng::from_entropy());
 
     let formats = [
-        "7z", "tar", "zip", "tar.gz", "tgz", "tbz", "tbz2", "txz", "tlzma", "tzst", "tar.bz", "tar.bz2", "tar.lzma",
+        "7z", "tar", "zip", "tar.gz", "tgz", "tbz", "tbz2", "txz", "tlzma", "tzst", "tzstd", "tar.bz", "tar.bz2", "tar.lzma",
         "tar.xz", "tar.zst",
     ];
 
@@ -31,6 +31,7 @@ fn sanity_check_through_mime() {
         "application/x-bzip2",
         "application/x-xz",
         "application/x-xz",
+        "application/zstd",
         "application/zstd",
         "application/x-bzip2",
         "application/x-bzip2",

--- a/tests/mime.rs
+++ b/tests/mime.rs
@@ -17,8 +17,8 @@ fn sanity_check_through_mime() {
     write_random_content(test_file, &mut SmallRng::from_entropy());
 
     let formats = [
-        "7z", "tar", "zip", "tar.gz", "tgz", "tbz", "tbz2", "txz", "tlzma", "tzst", "tzstd", "tar.bz", "tar.bz2", "tar.lzma",
-        "tar.xz", "tar.zst",
+        "7z", "tar", "zip", "tar.gz", "tgz", "tbz", "tbz2", "txz", "tlzma", "tzst", "tzstd", "tar.bz", "tar.bz2",
+        "tar.lzma", "tar.xz", "tar.zst",
     ];
 
     let expected_mimes = [

--- a/tests/snapshots/ui__ui_test_err_decompress_missing_extension_with_rar-1.snap
+++ b/tests/snapshots/ui__ui_test_err_decompress_missing_extension_with_rar-1.snap
@@ -7,7 +7,7 @@ expression: "run_ouch(\"ouch decompress a\", dir)"
  - Decompression formats are detected automatically from file extension
 
 hint: Supported extensions are: tar, zip, bz, bz2, gz, lz4, xz, lzma, sz, zst, rar, 7z
-hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst
+hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst, zstd, tzstd
 hint: 
 hint: Alternatively, you can pass an extension to the '--format' flag:
 hint:   ouch decompress <TMP_DIR>/a --format tar.gz

--- a/tests/snapshots/ui__ui_test_err_decompress_missing_extension_with_rar-2.snap
+++ b/tests/snapshots/ui__ui_test_err_decompress_missing_extension_with_rar-2.snap
@@ -8,5 +8,5 @@ expression: "run_ouch(\"ouch decompress a b.unknown\", dir)"
  - Decompression formats are detected automatically from file extension
 
 hint: Supported extensions are: tar, zip, bz, bz2, gz, lz4, xz, lzma, sz, zst, rar, 7z
-hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst
+hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst, zstd, tzstd
 

--- a/tests/snapshots/ui__ui_test_err_decompress_missing_extension_with_rar-3.snap
+++ b/tests/snapshots/ui__ui_test_err_decompress_missing_extension_with_rar-3.snap
@@ -7,7 +7,7 @@ expression: "run_ouch(\"ouch decompress b.unknown\", dir)"
  - Decompression formats are detected automatically from file extension
 
 hint: Supported extensions are: tar, zip, bz, bz2, gz, lz4, xz, lzma, sz, zst, rar, 7z
-hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst
+hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst, zstd, tzstd
 hint: 
 hint: Alternatively, you can pass an extension to the '--format' flag:
 hint:   ouch decompress <TMP_DIR>/b.unknown --format tar.gz

--- a/tests/snapshots/ui__ui_test_err_decompress_missing_extension_without_rar-1.snap
+++ b/tests/snapshots/ui__ui_test_err_decompress_missing_extension_without_rar-1.snap
@@ -7,7 +7,7 @@ expression: "run_ouch(\"ouch decompress a\", dir)"
  - Decompression formats are detected automatically from file extension
 
 hint: Supported extensions are: tar, zip, bz, bz2, gz, lz4, xz, lzma, sz, zst, 7z
-hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst
+hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst, zstd, tzstd
 hint: 
 hint: Alternatively, you can pass an extension to the '--format' flag:
 hint:   ouch decompress <TMP_DIR>/a --format tar.gz

--- a/tests/snapshots/ui__ui_test_err_decompress_missing_extension_without_rar-2.snap
+++ b/tests/snapshots/ui__ui_test_err_decompress_missing_extension_without_rar-2.snap
@@ -8,5 +8,5 @@ expression: "run_ouch(\"ouch decompress a b.unknown\", dir)"
  - Decompression formats are detected automatically from file extension
 
 hint: Supported extensions are: tar, zip, bz, bz2, gz, lz4, xz, lzma, sz, zst, 7z
-hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst
+hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst, zstd, tzstd
 

--- a/tests/snapshots/ui__ui_test_err_decompress_missing_extension_without_rar-3.snap
+++ b/tests/snapshots/ui__ui_test_err_decompress_missing_extension_without_rar-3.snap
@@ -7,7 +7,7 @@ expression: "run_ouch(\"ouch decompress b.unknown\", dir)"
  - Decompression formats are detected automatically from file extension
 
 hint: Supported extensions are: tar, zip, bz, bz2, gz, lz4, xz, lzma, sz, zst, 7z
-hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst
+hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst, zstd, tzstd
 hint: 
 hint: Alternatively, you can pass an extension to the '--format' flag:
 hint:   ouch decompress <TMP_DIR>/b.unknown --format tar.gz


### PR DESCRIPTION
Closes #608.

- [X] Added `zstd` alias
- [X] Added `tzstd` alias
- [X] Updated UI test outputs (added new pretty formats)
- [X] Added `tests/mime.rs - sanity_check_through_mime` test case for `tzstd`
- [ ] Included alias in changelog

Making it a draft for now as I'm not sure if I should include anything else in the PR (maybe some additional tests?).

"tested" that it works locally with

```sh
cargo r -- c CHANGELOG.md tmp.zstd
cargo r -- d tmp.zstd
```

On a side note, I work on windows and the `ui` tests don't run here without WSL because [`touch`](https://github.com/ouch-org/ouch/blob/49e2481d06ea3dd2cd9dd624c387aa35ea224626/tests/ui.rs#L57) is used a few times in the tests. Is there a reason for this or would it be fine to make a PR that swaps that out for `std::fs::File::create` 👀 