### PR TITLE
Add CI caching

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -99,6 +99,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
+          prefix-key: "v1"
           key: "${{ matrix.target }}-${{ matrix.feature-unrar }}-${{ matrix.feature-use-zstd-thin }}-${{ matrix.feature-unrar }}"
 
       - name: Test on stable

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -99,7 +99,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          key: "${{ matrix.target }}-${{ join(matrix.feature-use-zlib, '_') }}-${{ join(matrix.feature-use-zstd-thin, '_') }}-${{ join(matrix.feature-unrar, '_') }}"
+          key: "${{ matrix.target }}-${{ matrix.feature-unrar }}-${{ matrix.feature-use-zstd-thin }}-${{ matrix.feature-unrar }}"
 
       - name: Test on stable
         # there's no way to run tests for ARM64 Windows for now

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -98,7 +98,6 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "v1"
           key: "${{ matrix.target }}-${{ matrix.feature-unrar }}-${{ matrix.feature-use-zstd-thin }}-${{ matrix.feature-unrar }}"
 
       - name: Test on stable

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - ciCaching # TODO: Remove before merging
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
   pull_request:
@@ -95,6 +96,10 @@ jobs:
       - name: Install Rust
         run: |
           rustup toolchain install stable nightly --profile minimal -t ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: "${{ matrix.target }}-${{ env.EXTRA_CARGO_FLAGS }}"
 
       - name: Test on stable
         # there's no way to run tests for ARM64 Windows for now

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -99,7 +99,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          key: "${{ matrix.target }}-${{ env.EXTRA_CARGO_FLAGS }}"
+          key: "${{ matrix.target }}-${{ join(matrix.feature-use-zlib, '_') }}-${{ join(matrix.feature-use-zstd-thin, '_') }}-${{ join(matrix.feature-unrar, '_') }}"
 
       - name: Test on stable
         # there's no way to run tests for ARM64 Windows for now

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - ciCaching # TODO: Remove before merging
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
   pull_request:


### PR DESCRIPTION
Speeds up CI by caching dependencies.

Some numbers from my fork:
- [Clear cache - 16m 15s](https://github.com/AntoniosBarotsis/ouch/actions/runs/7667084187)
- [With cache - 9m 22s](https://github.com/AntoniosBarotsis/ouch/actions/runs/7667256203)

