### PR TITLE
Make UI tests cross platform (and somewhat faster)

### DIFF
--- a/src/commands/decompress.rs
+++ b/src/commands/decompress.rs
@@ -18,12 +18,12 @@ use crate::{
     QuestionAction, QuestionPolicy, BUFFER_CAPACITY,
 };
 
-// Decompress a file
-//
-// File at input_file_path is opened for reading, example: "archive.tar.gz"
-// formats contains each format necessary for decompression, example: [Gz, Tar] (in decompression order)
-// output_dir it's where the file will be decompressed to, this function assumes that the directory exists
-// output_file_path is only used when extracting single file formats, not archive formats like .tar or .zip
+/// Decompress a file
+///
+/// File at input_file_path is opened for reading, example: "archive.tar.gz"
+/// formats contains each format necessary for decompression, example: [Gz, Tar] (in decompression order)
+/// output_dir it's where the file will be decompressed to, this function assumes that the directory exists
+/// output_file_path is only used when extracting single file formats, not archive formats like .tar or .zip
 pub fn decompress_file(
     input_file_path: &Path,
     formats: Vec<Extension>,

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -13,8 +13,8 @@ use crate::{
     QuestionAction, QuestionPolicy, BUFFER_CAPACITY,
 };
 
-// File at input_file_path is opened for reading, example: "archive.tar.gz"
-// formats contains each format necessary for decompression, example: [Gz, Tar] (in decompression order)
+/// File at input_file_path is opened for reading, example: "archive.tar.gz"
+/// formats contains each format necessary for decompression, example: [Gz, Tar] (in decompression order)
 pub fn list_archive_contents(
     archive_path: &Path,
     formats: Vec<CompressionFormat>,

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -197,7 +197,7 @@ pub fn extensions_from_path(path: &Path) -> Vec<Extension> {
     extensions
 }
 
-// Panics if formats has an empty list of compression formats
+/// Panics if formats has an empty list of compression formats
 pub fn split_first_compression_format(formats: &[Extension]) -> (CompressionFormat, Vec<CompressionFormat>) {
     let mut extensions: Vec<CompressionFormat> = flatten_compression_formats(formats);
     let first_extension = extensions.remove(0);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -12,7 +12,7 @@ use test_strategy::{proptest, Arbitrary};
 
 use crate::utils::{assert_same_directory, write_random_content};
 
-// tar and zip extensions
+/// tar and zip extensions
 #[derive(Arbitrary, Debug, Display)]
 #[display(style = "lowercase")]
 enum DirectoryExtension {
@@ -30,7 +30,7 @@ enum DirectoryExtension {
     Zip,
 }
 
-// extensions of single file compression formats
+/// Extensions of single file compression formats
 #[derive(Arbitrary, Debug, Display)]
 #[display(style = "lowercase")]
 enum FileExtension {
@@ -51,7 +51,7 @@ enum Extension {
     File(FileExtension),
 }
 
-// converts a list of extension structs to string
+/// Converts a list of extension structs to string
 fn merge_extensions(ext: impl ToString, exts: Vec<FileExtension>) -> String {
     once(ext.to_string())
         .chain(exts.into_iter().map(|x| x.to_string()))
@@ -59,7 +59,7 @@ fn merge_extensions(ext: impl ToString, exts: Vec<FileExtension>) -> String {
         .join(".")
 }
 
-// create random nested directories and files under the specified directory
+/// Create random nested directories and files under the specified directory
 fn create_random_files(dir: impl Into<PathBuf>, depth: u8, rng: &mut SmallRng) {
     if depth == 0 {
         return;
@@ -81,7 +81,7 @@ fn create_random_files(dir: impl Into<PathBuf>, depth: u8, rng: &mut SmallRng) {
     }
 }
 
-// compress and decompress a single empty file
+/// Compress and decompress a single empty file
 #[proptest(cases = 200)]
 fn single_empty_file(ext: Extension, #[any(size_range(0..8).lift())] exts: Vec<FileExtension>) {
     let dir = tempdir().unwrap();
@@ -100,7 +100,7 @@ fn single_empty_file(ext: Extension, #[any(size_range(0..8).lift())] exts: Vec<F
     assert_same_directory(before, after, false);
 }
 
-// compress and decompress a single file
+/// Compress and decompress a single file
 #[proptest(cases = 250)]
 fn single_file(
     ext: Extension,
@@ -128,10 +128,10 @@ fn single_file(
     assert_same_directory(before, after, false);
 }
 
-// compress and decompress a directory with random content generated with create_random_files
-//
-// this one runs only 50 times because there are only `.zip` and `.tar` to be tested, and
-// single-file formats testing is done in the other test
+/// Compress and decompress a directory with random content generated with create_random_files
+///
+/// This one runs only 50 times because there are only `.zip` and `.tar` to be tested, and
+/// single-file formats testing is done in the other test
 #[proptest(cases = 50)]
 fn multiple_files(
     ext: DirectoryExtension,

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -11,7 +11,7 @@ use std::{ffi::OsStr, io, path::Path, process::Output};
 use insta::assert_display_snapshot as ui;
 use regex::Regex;
 
-use crate::utils::run_in;
+use crate::utils::create_files_in;
 
 fn testdir() -> io::Result<(tempfile::TempDir, &'static Path)> {
     let dir = tempfile::tempdir()?;
@@ -54,7 +54,7 @@ fn ui_test_err_compress_missing_extension() {
     let (_dropper, dir) = testdir().unwrap();
 
     // prepare
-    run_in(dir, "touch", "input").unwrap();
+    create_files_in(dir, &["input"]);
 
     ui!(run_ouch("ouch compress input output", dir));
 }
@@ -63,7 +63,7 @@ fn ui_test_err_compress_missing_extension() {
 fn ui_test_err_decompress_missing_extension() {
     let (_dropper, dir) = testdir().unwrap();
 
-    run_in(dir, "touch", "a b.unknown").unwrap();
+    create_files_in(dir, &["a", "b.unknown"]);
 
     let name = {
         let suffix = if cfg!(feature = "unrar") {
@@ -92,7 +92,7 @@ fn ui_test_ok_compress() {
     let (_dropper, dir) = testdir().unwrap();
 
     // prepare
-    run_in(dir, "touch", "input").unwrap();
+    create_files_in(dir, &["input"]);
 
     ui!(run_ouch("ouch compress input output.zip", dir));
     ui!(run_ouch("ouch compress input output.gz", dir));
@@ -103,7 +103,7 @@ fn ui_test_ok_decompress() {
     let (_dropper, dir) = testdir().unwrap();
 
     // prepare
-    run_in(dir, "touch", "input").unwrap();
+    create_files_in(dir, &["input"]);
     run_ouch("ouch compress input output.zst", dir);
 
     ui!(run_ouch("ouch decompress output.zst", dir));

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -51,8 +51,7 @@ pub fn create_files_in(dir: &Path, files: &[&str]) {
 
 // write random content to a file
 pub fn write_random_content(file: &mut impl Write, rng: &mut impl RngCore) {
-    let mut data = Vec::new();
-    data.resize(rng.gen_range(0..4096), 0);
+    let mut data = vec![0; rng.gen_range(0..4096)];
     rng.fill_bytes(&mut data);
     file.write_all(&data).unwrap();
 }

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -11,7 +11,7 @@ use assert_cmd::Command;
 use fs_err as fs;
 use rand::{Rng, RngCore};
 
-// Run ouch with the provided arguments, returns `assert_cmd::Output`
+/// Run ouch with the provided arguments, returns [`assert_cmd::Output`]
 #[macro_export]
 macro_rules! ouch {
     ($($e:expr),*) => {
@@ -49,15 +49,15 @@ pub fn create_files_in(dir: &Path, files: &[&str]) {
     } 
  }
 
-// write random content to a file
+/// Write random content to a file
 pub fn write_random_content(file: &mut impl Write, rng: &mut impl RngCore) {
     let mut data = vec![0; rng.gen_range(0..4096)];
     rng.fill_bytes(&mut data);
     file.write_all(&data).unwrap();
 }
 
-// check that two directories have the exact same content recursively
-// checks equility of file types if preserve_permissions is true, ignored on non-unix
+/// Check that two directories have the exact same content recursively.
+/// Checks equility of file types if preserve_permissions is true, ignored on non-unix
 // Silence clippy warning that triggers because of the `#[cfg(unix)]` on Windows.
 #[allow(clippy::only_used_in_recursion)]
 pub fn assert_same_directory(x: impl Into<PathBuf>, y: impl Into<PathBuf>, preserve_permissions: bool) {

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -3,11 +3,8 @@
 
 use std::{
     env,
-    ffi::OsStr,
-    io,
     io::Write,
     path::{Path, PathBuf},
-    process::Output,
 };
 
 use assert_cmd::Command;
@@ -38,15 +35,19 @@ pub fn cargo_bin() -> Command {
         .unwrap_or_else(|| Command::cargo_bin("ouch").expect("Failed to find ouch executable"))
 }
 
-/// Run a command inside of another folder.
+/// Creates files in the specified directory.
 ///
-/// example: `run_in("/tmp", "touch", "a b c")`
-pub fn run_in(folder: impl AsRef<Path>, bin: impl AsRef<OsStr>, args: &str) -> io::Result<Output> {
-    Command::new(bin)
-        .args(args.split_whitespace())
-        .current_dir(folder)
-        .output()
-}
+/// ## Example
+/// 
+/// ```no_run
+/// let (_dropper, dir) = testdir().unwrap();
+/// create_files_in(dir, &["file1.txt", "file2.txt"]);
+/// ```
+pub fn create_files_in(dir: &Path, files: &[&str]) {
+    for f in files {
+     std::fs::File::create(dir.join(f)).unwrap();
+    } 
+ }
 
 // write random content to a file
 pub fn write_random_content(file: &mut impl Write, rng: &mut impl RngCore) {

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -38,16 +38,16 @@ pub fn cargo_bin() -> Command {
 /// Creates files in the specified directory.
 ///
 /// ## Example
-/// 
+///
 /// ```no_run
 /// let (_dropper, dir) = testdir().unwrap();
 /// create_files_in(dir, &["file1.txt", "file2.txt"]);
 /// ```
 pub fn create_files_in(dir: &Path, files: &[&str]) {
     for f in files {
-     std::fs::File::create(dir.join(f)).unwrap();
-    } 
- }
+        std::fs::File::create(dir.join(f)).unwrap();
+    }
+}
 
 /// Write random content to a file
 pub fn write_random_content(file: &mut impl Write, rng: &mut impl RngCore) {

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -58,6 +58,8 @@ pub fn write_random_content(file: &mut impl Write, rng: &mut impl RngCore) {
 
 // check that two directories have the exact same content recursively
 // checks equility of file types if preserve_permissions is true, ignored on non-unix
+// Silence clippy warning that triggers because of the `#[cfg(unix)]` on Windows.
+#[allow(clippy::only_used_in_recursion)]
 pub fn assert_same_directory(x: impl Into<PathBuf>, y: impl Into<PathBuf>, preserve_permissions: bool) {
     fn read_dir(dir: impl Into<PathBuf>) -> impl Iterator<Item = fs::DirEntry> {
         let mut dir: Vec<_> = fs::read_dir(dir).unwrap().map(|entry| entry.unwrap()).collect();


### PR DESCRIPTION
I briefly mentioned this in #610:

> On a side note, I work on windows and the `ui` tests don't run here without WSL because [`touch`](https://github.com/ouch-org/ouch/blob/49e2481d06ea3dd2cd9dd624c387aa35ea224626/tests/ui.rs#L57) is used a few times in the tests. Is there a reason for this or would it be fine to make a PR that swaps that out for `std::fs::File::create` 👀 

There does not seem to be a reason for this, I'm guessing the function was likely used for more than just `touch` in the past but this is no longer the case so it's trivial to remove it. The tests now take ~20s on Windows instead of a few minutes. This should also be a speedup to all platforms since spawning an entire shell is expensive compared to just creating a file although since this was not used in the property tests, the difference should be marginal if at all noticable.

The `create_files_in` function is not really needed and just adding the `std::fs::File::create` statements is likely easier, I just tried keeping the code as similar as possible to before this change, let me know if you want me to just use `std::fs::File::create`s directly instead.

The PR also changes a bunch of code comments that were using 2 forward slashes into using 3 so they appear in code editor's inlay hints which is completely unrelated to everything else but might as well 😅 