### PR TITLE
Fix confusion between empty/nonempty test.

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -91,10 +91,7 @@ fn single_empty_file(ext: Extension, #[any(size_range(0..8).lift())] exts: Vec<F
     let before_file = &before.join("file");
     let archive = &dir.join(format!("file.{}", merge_extensions(ext, exts)));
     let after = &dir.join("after");
-    write_random_content(
-        &mut fs::File::create(before_file).unwrap(),
-        &mut SmallRng::from_entropy(),
-    );
+    fs::write(before_file, []).unwrap();
     ouch!("-A", "c", before_file, archive);
     ouch!("-A", "d", archive, "-d", after);
     assert_same_directory(before, after, false);
@@ -118,7 +115,10 @@ fn single_file(
     let before_file = &before.join("file");
     let archive = &dir.join(format!("file.{}", merge_extensions(ext, exts)));
     let after = &dir.join("after");
-    fs::write(before_file, []).unwrap();
+    write_random_content(
+        &mut fs::File::create(before_file).unwrap(),
+        &mut SmallRng::from_entropy(),
+    );
     if let Some(level) = level {
         ouch!("-A", "c", "-l", level.to_string(), before_file, archive);
     } else {


### PR DESCRIPTION
The single_empty_file test was writing random content to the file,
whereas the single_file test was writing an empty file.
Only the latter tested different levels, so I figured that test
was the one that should be using actual file content.

<!--
Make sure to check out CONTRIBUTING.md.
Don't forget to add a CHANGELOG.md entry!
-->
