### PR TITLE
Support decompressing stdin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Categories Used:
 ### Improvements
 
 - Fix logging IO bottleneck [\#642](https://github.com/ouch-org/ouch/pull/642) ([AntoniosBarotsis](https://github.com/AntoniosBarotsis))
+- Support decompression  over stdin [\#692](https://github.com/ouch-org/ouch/pull/692) ([rcorre](https://github.com/rcorre))
 
 ## [0.5.1](https://github.com/ouch-org/ouch/compare/0.5.0...0.5.1)
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -77,7 +77,7 @@ pub enum Subcommand {
     /// Decompresses one or more files, optionally into another folder
     #[command(visible_alias = "d")]
     Decompress {
-        /// Files to be decompressed
+        /// Files to be decompressed, or "-" for stdin
         #[arg(required = true, num_args = 1.., value_hint = ValueHint::FilePath)]
         files: Vec<PathBuf>,
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,7 +11,11 @@ use clap::Parser;
 use fs_err as fs;
 
 pub use self::args::{CliArgs, Subcommand};
-use crate::{accessible::set_accessible, utils::FileVisibilityPolicy, QuestionPolicy};
+use crate::{
+    accessible::set_accessible,
+    utils::{is_path_stdin, FileVisibilityPolicy},
+    QuestionPolicy,
+};
 
 impl CliArgs {
     /// A helper method that calls `clap::Parser::parse`.
@@ -47,5 +51,14 @@ impl CliArgs {
 }
 
 fn canonicalize_files(files: &[impl AsRef<Path>]) -> io::Result<Vec<PathBuf>> {
-    files.iter().map(fs::canonicalize).collect()
+    files
+        .iter()
+        .map(|f| {
+            if is_path_stdin(f.as_ref()) {
+                Ok(f.as_ref().to_path_buf())
+            } else {
+                fs::canonicalize(f)
+            }
+        })
+        .collect()
 }

--- a/src/commands/decompress.rs
+++ b/src/commands/decompress.rs
@@ -234,6 +234,7 @@ pub fn decompress_file(
 /// - If the archive contains only one file, it will be extracted to the `output_dir`
 /// - If the archive contains multiple files, it will be extracted to a subdirectory of the
 ///   output_dir named after the archive (given by `output_file_path`)
+///
 /// Note: This functions assumes that `output_dir` exists
 fn smart_unpack(
     unpack_fn: impl FnOnce(&Path) -> crate::Result<usize>,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -16,7 +16,9 @@ use crate::{
     error::{Error, FinalError},
     extension::{self, parse_format},
     list::ListOptions,
-    utils::{self, colors::*, logger::info_accessible, to_utf, EscapedPathDisplay, FileVisibilityPolicy},
+    utils::{
+        self, colors::*, is_path_stdin, logger::info_accessible, to_utf, EscapedPathDisplay, FileVisibilityPolicy,
+    },
     CliArgs, QuestionPolicy,
 };
 
@@ -173,7 +175,12 @@ pub fn run(
                 .zip(formats)
                 .zip(output_paths)
                 .try_for_each(|((input_path, formats), file_name)| {
-                    let output_file_path = output_dir.join(file_name); // Path used by single file format archives
+                    // Path used by single file format archives
+                    let output_file_path = if is_path_stdin(file_name) {
+                        output_dir.join("stdin-output")
+                    } else {
+                        output_dir.join(file_name)
+                    };
                     decompress_file(
                         input_path,
                         formats,

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -15,6 +15,10 @@ use crate::{
     QuestionPolicy,
 };
 
+pub fn is_path_stdin(path: &Path) -> bool {
+    path.as_os_str() == "-"
+}
+
 /// Remove `path` asking the user to overwrite if necessary.
 ///
 /// * `Ok(true)` means the path is clear,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -16,7 +16,8 @@ pub use formatting::{
     nice_directory_display, pretty_format_list_of_paths, strip_cur_dir, to_utf, Bytes, EscapedPathDisplay,
 };
 pub use fs::{
-    cd_into_same_dir_as, clear_path, create_dir_if_non_existent, is_symlink, remove_file_or_dir, try_infer_extension,
+    cd_into_same_dir_as, clear_path, create_dir_if_non_existent, is_path_stdin, is_symlink, remove_file_or_dir,
+    try_infer_extension,
 };
 pub use question::{
     ask_to_create_file, user_wants_to_continue, user_wants_to_overwrite, QuestionAction, QuestionPolicy,

--- a/src/utils/question.rs
+++ b/src/utils/question.rs
@@ -5,7 +5,7 @@
 
 use std::{
     borrow::Cow,
-    io::{stdin, BufRead},
+    io::{stdin, BufRead, IsTerminal},
     path::Path,
 };
 
@@ -120,6 +120,12 @@ impl<'a> Confirmation<'a> {
             (Some(_), None) => unreachable!("dev error, should be reported, we checked this won't happen"),
             (Some(placeholder), Some(subs)) => Cow::Owned(self.prompt.replace(placeholder, subs)),
         };
+
+        if !stdin().is_terminal() {
+            eprintln!("{}", message);
+            eprintln!("Pass --yes to proceed");
+            return Ok(false);
+        }
 
         let _locks = lock_and_flush_output_stdio()?;
         let mut stdin_lock = stdin().lock();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -144,7 +144,7 @@ fn single_file_stdin(
     let before = &dir.join("before");
     fs::create_dir(before).unwrap();
     let before_file = &before.join("file");
-    let format = merge_extensions(ext, exts);
+    let format = merge_extensions(&ext, exts);
     let archive = &dir.join(format!("file.{}", format));
     let after = &dir.join("after");
     write_random_content(
@@ -162,6 +162,14 @@ fn single_file_stdin(
         .unwrap()
         .assert()
         .success();
+
+    match ext {
+        Extension::Directory(_) => {}
+        // We don't know the original filename, so we create a file named stdin-output
+        // Change the top-level "before" directory to match
+        Extension::File(_) => fs::rename(before_file, before_file.with_file_name("stdin-output")).unwrap(),
+    };
+
     assert_same_directory(before, after, false);
 }
 

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -73,7 +73,10 @@ pub fn assert_same_directory(x: impl Into<PathBuf>, y: impl Into<PathBuf>, prese
     loop {
         match (x.next(), y.next()) {
             (Some(x), Some(y)) => {
-                assert_eq!(x.file_name(), y.file_name());
+                // If decompressing from stdin, the file name will be "-".
+                if x.file_name() != "-" && y.file_name() != "-" {
+                    assert_eq!(x.file_name(), y.file_name());
+                }
 
                 let meta_x = x.metadata().unwrap();
                 let meta_y = y.metadata().unwrap();

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -73,10 +73,7 @@ pub fn assert_same_directory(x: impl Into<PathBuf>, y: impl Into<PathBuf>, prese
     loop {
         match (x.next(), y.next()) {
             (Some(x), Some(y)) => {
-                // If decompressing from stdin, the file name will be "-".
-                if x.file_name() != "-" && y.file_name() != "-" {
-                    assert_eq!(x.file_name(), y.file_name());
-                }
+                assert_eq!(x.file_name(), y.file_name());
 
                 let meta_x = x.metadata().unwrap();
                 let meta_y = y.metadata().unwrap();


### PR DESCRIPTION
Fixes #687.

If "-" is passed as a filename, decompress data from stdin.

Currently `--format` must be passed as well, but as a next step,
we could try to infer the format from magic numbers.

As stdin is not connected to the terminal, we cannot prompt for Y/N
when warning about decompression in memory, for e.g. zip. Just default
to No, and require passing "-y" in these cases.

For zip, we have to buffer the whole stream in memory to seek into it,
just as we do with a chained decoder like `.zip.bz`.

The rar format requires an actual file (not an `impl Read`), so
we write a temp file that it can decode.

When decoding a single-file archive (e.g. file.bz), the output filename
is just `-`, since we don't know the original filename. I had to add
a bit of a hack to the tests to work around this. Another option
would be to interpret "-d" as a destination filename in this case.

When decoding a multi-file archive, I decided to unpack directly into
the destination directory, as this seemed like a better experience than
adding a top-level "-" folder inside the destination.

<!--
Make sure to check out CONTRIBUTING.md.
Don't forget to add a CHANGELOG.md entry!
-->
