### PR TITLE
DRAFT: Add landlock support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Categories Used:
 - Provide Nushell completions (packages still need to install them) [\#827](https://github.com/ouch-org/ouch/pull/827) ([FrancescElies](https://github.com/FrancescElies))
 - Support `.lz` decompression [\#838](https://github.com/ouch-org/ouch/pull/838) ([zzzsyyy](https://github.com/zzzsyyy))
 - Support `.lzma` decompression (and fix `.lzma` being a wrong alias for `.xz`) [\#838](https://github.com/ouch-org/ouch/pull/838) ([zzzsyyy](https://github.com/zzzsyyy))
+- Add landlock support for linux filesystem isolation [\#723](https://github.com/ouch-org/ouch/pull/723) ([valoq](https://github.com/valoq)) 
 
 ### Improvements
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ gzp = { version = "0.11.3", default-features = false, features = [
     "snappy_default",
 ] }
 ignore = "0.4.23"
+landlock = "0.4.2"
 libc = "0.2.155"
 linked-hash-map = "0.5.6"
 lz4_flex = "0.11.3"
@@ -39,6 +40,7 @@ sevenz-rust2 = { version = "0.13.1", features = ["compress", "aes256"] }
 snap = "1.1.1"
 tar = "0.4.42"
 tempfile = "3.10.1"
+thiserror = "2.0.12"
 time = { version = "0.3.36", default-features = false }
 unrar = { version = "0.5.7", optional = true }
 liblzma = "0.4"

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -49,6 +49,10 @@ pub struct CliArgs {
     #[arg(short = 'c', long, global = true)]
     pub threads: Option<usize>,
 
+    /// Disable the sandbox feature
+    #[arg(long, global = true)]
+    pub disable_sandbox: bool,
+
     // Ouch and claps subcommands
     #[command(subcommand)]
     pub cmd: Subcommand,
@@ -85,6 +89,10 @@ pub enum Subcommand {
         /// Archive target files instead of storing symlinks (supported by `tar` and `zip`)
         #[arg(long, short = 'S')]
         follow_symlinks: bool,
+
+        /// Mark sandbox as disabled
+        #[arg(long, global = true)]
+        disable_sandbox: bool,
     },
     /// Decompresses one or more files, optionally into another folder
     #[command(visible_alias = "d")]
@@ -104,6 +112,10 @@ pub enum Subcommand {
         /// Disable Smart Unpack
         #[arg(long)]
         no_smart_unpack: bool,
+
+        /// Mark sandbox as disabled
+        #[arg(long, global = true)]
+        disable_sandbox: bool,
     },
     /// List contents of an archive
     #[command(visible_aliases = ["l", "ls"])]
@@ -115,6 +127,10 @@ pub enum Subcommand {
         /// Show archive contents as a tree
         #[arg(short, long)]
         tree: bool,
+
+        /// Mark sandbox as disabled
+        #[arg(long, global = true)]
+        disable_sandbox: bool,
     },
 }
 
@@ -155,12 +171,14 @@ mod tests {
             // This is usually replaced in assertion tests
             password: None,
             threads: None,
+            disable_sandbox: false,
             cmd: Subcommand::Decompress {
                 // Put a crazy value here so no test can assert it unintentionally
                 files: vec!["\x00\x11\x22".into()],
                 output_dir: None,
                 remove: false,
                 no_smart_unpack: false,
+                disable_sandbox: false,
             },
         }
     }
@@ -175,6 +193,7 @@ mod tests {
                     output_dir: None,
                     remove: false,
                     no_smart_unpack: false,
+                    disable_sandbox: false,
                 },
                 ..mock_cli_args()
             }
@@ -187,6 +206,7 @@ mod tests {
                     output_dir: None,
                     remove: false,
                     no_smart_unpack: false,
+                    disable_sandbox: false,
                 },
                 ..mock_cli_args()
             }
@@ -199,6 +219,7 @@ mod tests {
                     output_dir: None,
                     remove: false,
                     no_smart_unpack: false,
+                    disable_sandbox: false,
                 },
                 ..mock_cli_args()
             }
@@ -214,6 +235,7 @@ mod tests {
                     fast: false,
                     slow: false,
                     follow_symlinks: false,
+                    disable_sandbox: false,
                 },
                 ..mock_cli_args()
             }
@@ -228,6 +250,7 @@ mod tests {
                     fast: false,
                     slow: false,
                     follow_symlinks: false,
+                    disable_sandbox: false,
                 },
                 ..mock_cli_args()
             }
@@ -242,6 +265,7 @@ mod tests {
                     fast: false,
                     slow: false,
                     follow_symlinks: false,
+                    disable_sandbox: false,
                 },
                 ..mock_cli_args()
             }
@@ -267,6 +291,7 @@ mod tests {
                         fast: false,
                         slow: false,
                         follow_symlinks: false,
+                        disable_sandbox: false,
                     },
                     format: Some("tar.gz".into()),
                     ..mock_cli_args()

--- a/src/commands/compress.rs
+++ b/src/commands/compress.rs
@@ -35,6 +35,7 @@ pub fn compress_files(
     question_policy: QuestionPolicy,
     file_visibility_policy: FileVisibilityPolicy,
     level: Option<i16>,
+    disable_sandbox: bool,
 ) -> crate::Result<bool> {
     // If the input files contain a directory, then the total size will be underestimated
     let file_writer = BufWriter::with_capacity(BUFFER_CAPACITY, output_file);

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -69,6 +69,7 @@ pub fn run(
             fast,
             slow,
             follow_symlinks,
+            disable_sandbox,
         } => {
             // After cleaning, if there are no input files left, exit
             if files.is_empty() {
@@ -116,6 +117,7 @@ pub fn run(
                 question_policy,
                 file_visibility_policy,
                 level,
+                args.disable_sandbox,
             );
 
             if let Ok(true) = compress_result {
@@ -151,6 +153,7 @@ pub fn run(
             output_dir,
             remove,
             no_smart_unpack,
+            disable_sandbox,
         } => {
             let mut output_paths = vec![];
             let mut formats = vec![];
@@ -216,10 +219,12 @@ pub fn run(
                             <[u8] as ByteSlice>::from_os_str(str).expect("convert password to bytes failed")
                         }),
                         remove,
+                        disable_sandbox: args.disable_sandbox,
                     })
                 })
         }
-        Subcommand::List { archives: files, tree } => {
+        // check again if we need to provide disable_sandbox as argument here
+        Subcommand::List { archives: files, tree, disable_sandbox} => {
             let mut formats = vec![];
 
             if let Some(format) = args.format {
@@ -257,9 +262,9 @@ pub fn run(
                     args.password
                         .as_deref()
                         .map(|str| <[u8] as ByteSlice>::from_os_str(str).expect("convert password to bytes failed")),
+                    args.disable_sandbox,
                 )?;
             }
-
             Ok(())
         }
     }

--- a/src/utils/landlock.rs
+++ b/src/utils/landlock.rs
@@ -1,0 +1,114 @@
+// Landlock support and generic Landlock sandbox implementation.
+// https://landlock.io/rust-landlock/landlock/struct.Ruleset.html
+
+use std::path::Path;
+
+use landlock::{
+    Access, AccessFs, PathBeneath, PathFd, PathFdError, RestrictionStatus, Ruleset,
+    RulesetAttr, RulesetCreatedAttr, RulesetError, ABI,
+};
+use thiserror::Error;
+
+/// The status code returned from `ouch` on error
+pub const EXIT_FAILURE: i32 = libc::EXIT_FAILURE;
+
+/// Returns true if Landlock is supported by the running kernel (Linux kernel >= 5.19).
+#[cfg(target_os = "linux")]
+pub fn is_landlock_supported() -> bool {
+    use std::process::Command;
+
+    if let Ok(output) = Command::new("uname").arg("-r").output() {
+        if let Ok(version_str) = String::from_utf8(output.stdout) {
+            // Version string is expected to be in "5.19.0-foo" or similar
+            let mut parts = version_str.trim().split('.');
+            if let (Some(major), Some(minor)) = (parts.next(), parts.next()) {
+                if let (Ok(major), Ok(minor)) = (major.parse::<u32>(), minor.parse::<u32>()) {
+                    return (major > 5) || (major == 5 && minor >= 19);
+                }
+            }
+        }
+    }
+    false
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn is_landlock_supported() -> bool {
+    false
+}
+
+#[derive(Debug, Error)]
+pub enum MyRestrictError {
+    #[error(transparent)]
+    Ruleset(#[from] RulesetError),
+    #[error(transparent)]
+    AddRule(#[from] PathFdError),
+}
+
+/// Restricts the process to only access the given hierarchies using Landlock, if supported.
+///
+/// The Landlock ABI is set to v2 for compatibility with Linux 5.19+.
+/// All hierarchies are given full access, but root ("/") is read-only.
+fn restrict_paths(hierarchies: &[&str]) -> Result<RestrictionStatus, MyRestrictError> {
+    // The Landlock ABI should be incremented (and tested) regularly.
+    // ABI set to 2 in compatibility with linux 5.19 and higher
+    let abi = ABI::V2;
+    let access_all = AccessFs::from_all(abi);
+    let access_read = AccessFs::from_read(abi);
+
+    let mut ruleset = Ruleset::default()
+        .handle_access(access_all)?
+        .create()?
+        // Read-only access to / (entire filesystem).
+        .add_rules(landlock::path_beneath_rules(&["/"], access_read))?;
+
+    // Add write permissions to specified directory of provided
+    if !hierarchies.is_empty() {
+        ruleset = ruleset.add_rules(
+            hierarchies
+                .iter()
+                .map::<Result<_, MyRestrictError>, _>(|p| {
+                    Ok(PathBeneath::new(PathFd::new(p)?, access_all))
+                }),
+        )?;
+    }
+
+    Ok(ruleset.restrict_self()?)
+}
+
+/// Restricts the process to only access the given hierarchies using Landlock, if supported.
+/// Accepts multiple allowed directories as &[&Path].
+pub fn init_sandbox(allowed_dirs: &[&Path], disable_sandbox: bool) {
+    // if std::env::var("CI").is_ok() {
+    //    return;
+    // }
+    if disable_sandbox {
+        println!("Sandbox feature disabled via --no-sandbox flag.");
+        // warn!("Security Process isolation disabled");
+        return;
+    }
+
+    if is_landlock_supported() {
+        let paths: Vec<&str> = allowed_dirs
+            .iter()
+            .map(|p| p.to_str().expect("Cannot convert path"))
+            .collect();
+
+        let status = if !paths.is_empty() {
+            restrict_paths(&paths)
+        } else {
+            restrict_paths(&[])
+        };
+
+        match status {
+            Ok(_status) => {
+                //check
+            }
+            Err(_e) => {
+                //log warning
+                std::process::exit(EXIT_FAILURE);
+            }
+        }
+    } else {
+        // warn!("Landlock is NOT supported on this platform or kernel (<5.19).");
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -8,6 +8,7 @@ mod file_visibility;
 mod formatting;
 mod fs;
 pub mod io;
+pub mod landlock;
 pub mod logger;
 mod question;
 

--- a/src/utils/src_utils_landlock.rs
+++ b/src/utils/src_utils_landlock.rs
@@ -1,0 +1,109 @@
+// Landlock support and generic Landlock sandbox implementation.
+// https://landlock.io/rust-landlock/landlock/struct.Ruleset.html
+
+use landlock::{
+    Access, AccessFs, PathBeneath, PathFd, PathFdError, RestrictionStatus, Ruleset,
+    RulesetAttr, RulesetCreatedAttr, RulesetError, ABI,
+};
+use thiserror::Error;
+
+use std::path::Path;
+
+/// The status code returned from `ouch` on error
+pub const EXIT_FAILURE: i32 = libc::EXIT_FAILURE;
+
+/// Returns true if Landlock is supported by the running kernel (Linux kernel >= 5.19).
+#[cfg(target_os = "linux")]
+pub fn is_landlock_supported() -> bool {
+    use std::process::Command;
+
+    if let Ok(output) = Command::new("uname").arg("-r").output() {
+        if let Ok(version_str) = String::from_utf8(output.stdout) {
+            // Version string is expected to be in "5.19.0-foo" or similar
+            let mut parts = version_str.trim().split('.');
+            if let (Some(major), Some(minor)) = (parts.next(), parts.next()) {
+                if let (Ok(major), Ok(minor)) = (major.parse::<u32>(), minor.parse::<u32>()) {
+                    return (major > 5) || (major == 5 && minor >= 19);
+                }
+            }
+        }
+    }
+    false
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn is_landlock_supported() -> bool {
+    false
+}
+
+#[derive(Debug, Error)]
+pub enum MyRestrictError {
+    #[error(transparent)]
+    Ruleset(#[from] RulesetError),
+    #[error(transparent)]
+    AddRule(#[from] PathFdError),
+}
+
+/// Restricts the process to only access the given hierarchies using Landlock, if supported.
+///
+/// The Landlock ABI is set to v2 for compatibility with Linux 5.19+.
+/// All hierarchies are given full access, but root ("/") is read-only.
+fn restrict_paths(hierarchies: &[&str]) -> Result<RestrictionStatus, MyRestrictError> {
+    // The Landlock ABI should be incremented (and tested) regularly.
+    // ABI set to 2 in compatibility with linux 5.19 and higher
+    let abi = ABI::V2;
+    let access_all = AccessFs::from_all(abi);
+    let access_read = AccessFs::from_read(abi);
+
+    let mut ruleset = Ruleset::default()
+        .handle_access(access_all)?
+        .create()?
+        // Read-only access to / (entire filesystem).
+        .add_rules(landlock::path_beneath_rules(&["/"], access_read))?;
+
+    // Add write permissions to specified directory of provided
+    if !hierarchies.is_empty() {
+        ruleset = ruleset.add_rules(
+            hierarchies
+                .iter()
+                .map::<Result<_, MyRestrictError>, _>(|p| {
+                    Ok(PathBeneath::new(PathFd::new(p)?, access_all))
+                }),
+        )?;
+    }
+
+    Ok(ruleset.restrict_self()?)
+}
+
+/// Restricts the process to only access the given hierarchies using Landlock, if supported.
+/// Accepts multiple allowed directories as &[&Path].
+pub fn init_sandbox(allowed_dirs: &[&Path]) {
+    // if std::env::var("CI").is_ok() {
+    //    return;
+    // }
+
+    if is_landlock_supported() {
+        let paths: Vec<&str> = allowed_dirs
+            .iter()
+            .map(|p| p.to_str().expect("Cannot convert path"))
+            .collect();
+
+        let status = if !paths.is_empty() {
+            restrict_paths(&paths)
+        } else {
+            restrict_paths(&[])
+        };
+
+        match status {
+            Ok(_status) => {
+                // check
+            }
+            Err(_e) => {
+                // log warning
+                std::process::exit(EXIT_FAILURE);
+            }
+        }
+    } else {
+        // warn!("Landlock is NOT supported on this platform or kernel (<5.19).");
+    }
+}

--- a/tests/landlock.rs
+++ b/tests/landlock.rs
@@ -1,0 +1,8 @@
+#[test]
+fn test_landlock_restriction() {
+    if !cfg!(target_os = "linux") {
+        eprintln!("Skipping Landlock test: not running on Linux.");
+        return;
+    }
+    // TODO: Add test
+}


### PR DESCRIPTION
This PR adds landlock filesystem isolation to ouch as discussed in #722 

At the moment this is just a quickly hacked implementation to demonstrate the use of landlock in ouch.
It restricts the entire filesystem to be read only and only permits write actions in the current working directory of the process.

In order to test the isolation feature, use the `-d `option to write the decompressed files to a path outside of `$PWD`
A final implementation would address the `-d` option as well to allow writing to specified output directories, but I left it untouched for now to allow an easy demonstration/test of the landlock feature.

Todo:
- restrict write permissions to the .tmp-XXXXXX directory, including permissions for said directory to rename itself to the final name LANDLOCK_ACCESS_FS_MAKE_DIR (This should avoid writing to any control files in $HOME like .bashrc)
- Identify all special cases that require permissions (see failed unit tests) 