### PR TITLE
Change temporary path to a more unique name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Categories Used:
 ### Tweaks
 
 - CI refactor [\#578](https://github.com/ouch-org/ouch/pull/578) ([cyqsimon](https://github.com/cyqsimon))
+- Use a more unique name for temporary decompression path [\#725](https://github.com/ouch-org/ouch/pull/725) ([valoq](https://github.com/valoq))
 
 ### Improvements
 

--- a/src/commands/decompress.rs
+++ b/src/commands/decompress.rs
@@ -248,7 +248,9 @@ fn smart_unpack(
     question_policy: QuestionPolicy,
 ) -> crate::Result<ControlFlow<(), usize>> {
     assert!(output_dir.exists());
-    let temp_dir = tempfile::tempdir_in(output_dir)?;
+    let temp_dir = tempfile::Builder::new()
+    .prefix(".tmp-ouch-")
+    .tempdir_in(output_dir)?;
     let temp_dir_path = temp_dir.path();
 
     info_accessible(format!(

--- a/src/commands/decompress.rs
+++ b/src/commands/decompress.rs
@@ -248,9 +248,7 @@ fn smart_unpack(
     question_policy: QuestionPolicy,
 ) -> crate::Result<ControlFlow<(), usize>> {
     assert!(output_dir.exists());
-    let temp_dir = tempfile::Builder::new()
-    .prefix(".tmp-ouch-")
-    .tempdir_in(output_dir)?;
+    let temp_dir = tempfile::Builder::new().prefix(".tmp-ouch-").tempdir_in(output_dir)?;
     let temp_dir_path = temp_dir.path();
 
     info_accessible(format!(


### PR DESCRIPTION
Addresses #685

This PR changes the temporary path for decompressing files from the previously used ".tmpXXXXXX" to a more unique ".tmp-ouch-XXXXXX" name in order to avoid collisions.

Note that while many applications start temporary file names with ".tmp-" it may also make sense to use  ".ouch-tmp-XXXXXX" or simply ".ouch-XXXXXX"

If there is a good reason to change it to one of the alternatives please let me know.