### PR TITLE
chore: simplify code after feature stabilization

### DIFF
--- a/src/archive/sevenz.rs
+++ b/src/archive/sevenz.rs
@@ -15,7 +15,7 @@ use crate::{
     error::{Error, FinalError},
     list::FileInArchive,
     utils::{
-        self, cd_into_same_dir_as,
+        cd_into_same_dir_as,
         logger::{info, warning},
         Bytes, EscapedPathDisplay, FileVisibilityPolicy,
     },
@@ -68,9 +68,8 @@ where
             let metadata = match path.metadata() {
                 Ok(metadata) => metadata,
                 Err(e) => {
-                    if e.kind() == std::io::ErrorKind::NotFound && utils::is_symlink(path) {
-                        // This path is for a broken symlink
-                        // We just ignore it
+                    if e.kind() == std::io::ErrorKind::NotFound && path.is_symlink() {
+                        // This path is for a broken symlink, ignore it
                         continue;
                     }
                     return Err(e.into());

--- a/src/archive/tar.rs
+++ b/src/archive/tar.rs
@@ -131,9 +131,8 @@ where
                 let mut file = match fs::File::open(path) {
                     Ok(f) => f,
                     Err(e) => {
-                        if e.kind() == std::io::ErrorKind::NotFound && utils::is_symlink(path) {
-                            // This path is for a broken symlink
-                            // We just ignore it
+                        if e.kind() == std::io::ErrorKind::NotFound && path.is_symlink() {
+                            // This path is for a broken symlink, ignore it
                             continue;
                         }
                         return Err(e.into());

--- a/src/archive/zip.rs
+++ b/src/archive/zip.rs
@@ -20,7 +20,7 @@ use crate::{
     error::FinalError,
     list::FileInArchive,
     utils::{
-        self, cd_into_same_dir_as, get_invalid_utf8_paths,
+        cd_into_same_dir_as, get_invalid_utf8_paths,
         logger::{info, info_accessible, warning},
         pretty_format_list_of_paths, strip_cur_dir, Bytes, EscapedPathDisplay, FileVisibilityPolicy,
     },
@@ -214,9 +214,8 @@ where
             let metadata = match path.metadata() {
                 Ok(metadata) => metadata,
                 Err(e) => {
-                    if e.kind() == std::io::ErrorKind::NotFound && utils::is_symlink(path) {
-                        // This path is for a broken symlink
-                        // We just ignore it
+                    if e.kind() == std::io::ErrorKind::NotFound && path.is_symlink() {
+                        // This path is for a broken symlink, ignore it
                         continue;
                     }
                     return Err(e.into());

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -146,13 +146,3 @@ pub fn try_infer_extension(path: &Path) -> Option<Extension> {
         None
     }
 }
-
-/// Returns true if a path is a symlink.
-///
-/// This is the same as the nightly <https://doc.rust-lang.org/std/path/struct.Path.html#method.is_symlink>
-/// Useful to detect broken symlinks when compressing. (So we can safely ignore them)
-pub fn is_symlink(path: &Path) -> bool {
-    fs::symlink_metadata(path)
-        .map(|m| m.file_type().is_symlink())
-        .unwrap_or(false)
-}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -18,7 +18,7 @@ pub use self::{
         EscapedPathDisplay,
     },
     fs::{
-        cd_into_same_dir_as, clear_path, create_dir_if_non_existent, is_path_stdin, is_symlink, remove_file_or_dir,
+        cd_into_same_dir_as, clear_path, create_dir_if_non_existent, is_path_stdin, remove_file_or_dir,
         try_infer_extension,
     },
     question::{ask_to_create_file, user_wants_to_continue, user_wants_to_overwrite, QuestionAction, QuestionPolicy},


### PR DESCRIPTION
no need to reimplement `Path::is_symlink` anymore
