### PR TITLE
fix: don't shutdown logger after flush

### DIFF
--- a/src/utils/logger.rs
+++ b/src/utils/logger.rs
@@ -218,13 +218,12 @@ mod logger_thread {
                         flush_logs_to_stderr(&mut buffer);
                     }
                 }
-                LoggerCommand::FlushAndShutdown => {
-                    flush_logs_to_stderr(&mut buffer);
-                    break;
-                }
                 LoggerCommand::Flush { finished_barrier } => {
                     flush_logs_to_stderr(&mut buffer);
                     finished_barrier.wait();
+                }
+                LoggerCommand::FlushAndShutdown => {
+                    flush_logs_to_stderr(&mut buffer);
                     break;
                 }
             }


### PR DESCRIPTION
<!--
If your code changes text output, you might need to update snapshots
of UI tests, read more about `insta` at CONTRIBUTING.md.

Remember to edit `CHANGELOG.md` after opening the PR.
-->
