### PR TITLE
tweak: don't log a period at end of all logs and warnings

### DIFF
--- a/src/archive/sevenz.rs
+++ b/src/archive/sevenz.rs
@@ -49,7 +49,7 @@ where
             if let Ok(handle) = &output_handle {
                 if matches!(Handle::from_path(path), Ok(x) if &x == handle) {
                     warning(format!(
-                        "Cannot compress `{}` into itself, skipping.",
+                        "Cannot compress `{}` into itself, skipping",
                         output_path.display()
                     ));
 
@@ -62,7 +62,7 @@ where
             // spoken text for users using screen readers, braille displays
             // and so on
             if !quiet {
-                info(format!("Compressing '{}'.", EscapedPathDisplay::new(path)));
+                info(format!("Compressing '{}'", EscapedPathDisplay::new(path)));
             }
 
             let metadata = match path.metadata() {

--- a/src/archive/tar.rs
+++ b/src/archive/tar.rs
@@ -109,7 +109,7 @@ where
             if let Ok(handle) = &output_handle {
                 if matches!(Handle::from_path(path), Ok(x) if &x == handle) {
                     warning(format!(
-                        "Cannot compress `{}` into itself, skipping.",
+                        "Cannot compress `{}` into itself, skipping",
                         output_path.display()
                     ));
 
@@ -122,7 +122,7 @@ where
             // spoken text for users using screen readers, braille displays
             // and so on
             if !quiet {
-                info(format!("Compressing '{}'.", EscapedPathDisplay::new(path)));
+                info(format!("Compressing '{}'", EscapedPathDisplay::new(path)));
             }
 
             if path.is_dir() {

--- a/src/archive/zip.rs
+++ b/src/archive/zip.rs
@@ -197,7 +197,7 @@ where
             if let Ok(handle) = &output_handle {
                 if matches!(Handle::from_path(path), Ok(x) if &x == handle) {
                     warning(format!(
-                        "Cannot compress `{}` into itself, skipping.",
+                        "Cannot compress `{}` into itself, skipping",
                         output_path.display()
                     ));
                 }
@@ -208,7 +208,7 @@ where
             // spoken text for users using screen readers, braille displays
             // and so on
             if !quiet {
-                info(format!("Compressing '{}'.", EscapedPathDisplay::new(path)));
+                info(format!("Compressing '{}'", EscapedPathDisplay::new(path)));
             }
 
             let metadata = match path.metadata() {

--- a/src/commands/decompress.rs
+++ b/src/commands/decompress.rs
@@ -78,7 +78,7 @@ pub fn decompress_file(
         // as screen readers may not read a commands exit code, making it hard to reason
         // about whether the command succeeded without such a message
         info_accessible(format!(
-            "Successfully decompressed archive in {} ({} files).",
+            "Successfully decompressed archive in {} ({} files)",
             nice_directory_display(output_dir),
             files_unpacked
         ));
@@ -228,7 +228,7 @@ pub fn decompress_file(
     // as screen readers may not read a commands exit code, making it hard to reason
     // about whether the command succeeded without such a message
     info_accessible(format!(
-        "Successfully decompressed archive in {}.",
+        "Successfully decompressed archive in {}",
         nice_directory_display(output_dir)
     ));
     info_accessible(format!("Files unpacked: {}", files_unpacked));
@@ -253,7 +253,7 @@ fn smart_unpack(
     let temp_dir_path = temp_dir.path();
 
     info_accessible(format!(
-        "Created temporary directory {} to hold decompressed elements.",
+        "Created temporary directory {} to hold decompressed elements",
         nice_directory_display(temp_dir_path)
     ));
 
@@ -283,7 +283,7 @@ fn smart_unpack(
     // Rename the temporary directory to the archive name, which is output_file_path
     fs::rename(&previous_path, &new_path)?;
     info_accessible(format!(
-        "Successfully moved \"{}\" to \"{}\".",
+        "Successfully moved \"{}\" to \"{}\"",
         nice_directory_display(&previous_path),
         nice_directory_display(&new_path),
     ));

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -111,7 +111,7 @@ pub fn run(
                 // having a final status message is important especially in an accessibility context
                 // as screen readers may not read a commands exit code, making it hard to reason
                 // about whether the command succeeded without such a message
-                info_accessible(format!("Successfully compressed '{}'.", path_to_str(&output_path)));
+                info_accessible(format!("Successfully compressed '{}'", path_to_str(&output_path)));
             } else {
                 // If Ok(false) or Err() occurred, delete incomplete file at `output_path`
                 //

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,7 +32,7 @@ pub enum Error {
     PermissionDenied { error_title: String },
     /// From zip::result::ZipError::UnsupportedArchive
     UnsupportedZipArchive(&'static str),
-    /// TO BE REMOVED
+    /// We don't support compressing the root folder.
     CompressingRootFolder,
     /// Specialized walkdir's io::Error wrapper with additional information on the error
     WalkdirError { reason: String },

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -200,7 +200,7 @@ pub fn separate_known_extensions_from_name(path: &Path) -> (&Path, Vec<Extension
         let file_stem = name.trim_matches('.');
         if SUPPORTED_EXTENSIONS.contains(&file_stem) || SUPPORTED_ALIASES.contains(&file_stem) {
             warning(format!(
-                "Received a file with name '{file_stem}', but {file_stem} was expected as the extension."
+                "Received a file with name '{file_stem}', but {file_stem} was expected as the extension"
             ));
         }
     }

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -49,7 +49,7 @@ pub fn create_dir_if_non_existent(path: &Path) -> crate::Result<()> {
         fs::create_dir_all(path)?;
         // creating a directory is an important change to the file system we
         // should always inform the user about
-        info_accessible(format!("Directory {} created.", EscapedPathDisplay::new(path)));
+        info_accessible(format!("Directory {} created", EscapedPathDisplay::new(path)));
     }
     Ok(())
 }


### PR DESCRIPTION
<!--
If your code changes text output, you might need to update snapshots
of UI tests, read more about `insta` at CONTRIBUTING.md.

Remember to edit `CHANGELOG.md` after opening the PR.
-->
