### PR TITLE
Cli: Fix typo in 'concurrent', improve other help texts

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -13,11 +13,11 @@ use clap::{Parser, ValueHint};
 // Disable rustdoc::bare_urls because rustdoc parses URLs differently than Clap
 #[allow(rustdoc::bare_urls)]
 pub struct CliArgs {
-    /// Skip [Y/n] questions positively
+    /// Skip [Y/n] questions, default to yes
     #[arg(short, long, conflicts_with = "no", global = true)]
     pub yes: bool,
 
-    /// Skip [Y/n] questions negatively
+    /// Skip [Y/n] questions, default to no
     #[arg(short, long, global = true)]
     pub no: bool,
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -45,7 +45,7 @@ pub struct CliArgs {
     #[arg(short = 'p', long = "password", global = true)]
     pub password: Option<OsString>,
 
-    /// cocurrent working threads
+    /// concurrent working threads
     #[arg(short = 'c', long, global = true)]
     pub threads: Option<usize>,
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -25,15 +25,15 @@ pub struct CliArgs {
     #[arg(short = 'A', long, env = "ACCESSIBLE", global = true)]
     pub accessible: bool,
 
-    /// Ignores hidden files
+    /// Ignore hidden files
     #[arg(short = 'H', long, global = true)]
     pub hidden: bool,
 
-    /// Silences output
+    /// Silence output
     #[arg(short = 'q', long, global = true)]
     pub quiet: bool,
 
-    /// Ignores files matched by git's ignore files
+    /// Ignore files matched by git's ignore files
     #[arg(short = 'g', long, global = true)]
     pub gitignore: bool,
 
@@ -41,11 +41,11 @@ pub struct CliArgs {
     #[arg(short, long, global = true)]
     pub format: Option<OsString>,
 
-    /// decompress or list with password
+    /// Decompress or list with password
     #[arg(short = 'p', long = "password", global = true)]
     pub password: Option<OsString>,
 
-    /// concurrent working threads
+    /// Concurrent working threads
     #[arg(short = 'c', long, global = true)]
     pub threads: Option<usize>,
 

--- a/tests/snapshots/ui__ui_test_usage_help_flag-2.snap
+++ b/tests/snapshots/ui__ui_test_usage_help_flag-2.snap
@@ -17,11 +17,11 @@ Options:
   -y, --yes                  Skip [Y/n] questions positively
   -n, --no                   Skip [Y/n] questions negatively
   -A, --accessible           Activate accessibility mode, reducing visual noise [env: ACCESSIBLE=]
-  -H, --hidden               Ignores hidden files
-  -q, --quiet                Silences output
-  -g, --gitignore            Ignores files matched by git's ignore files
+  -H, --hidden               Ignore hidden files
+  -q, --quiet                Silence output
+  -g, --gitignore            Ignore files matched by git's ignore files
   -f, --format <FORMAT>      Specify the format of the archive
-  -p, --password <PASSWORD>  decompress or list with password
-  -c, --threads <THREADS>    concurrent working threads
+  -p, --password <PASSWORD>  Decompress or list with password
+  -c, --threads <THREADS>    Concurrent working threads
   -h, --help                 Print help (see more with '--help')
   -V, --version              Print version

--- a/tests/snapshots/ui__ui_test_usage_help_flag-2.snap
+++ b/tests/snapshots/ui__ui_test_usage_help_flag-2.snap
@@ -14,8 +14,8 @@ Commands:
   help        Print this message or the help of the given subcommand(s)
 
 Options:
-  -y, --yes                  Skip [Y/n] questions positively
-  -n, --no                   Skip [Y/n] questions negatively
+  -y, --yes                  Skip [Y/n] questions, default to yes
+  -n, --no                   Skip [Y/n] questions, default to no
   -A, --accessible           Activate accessibility mode, reducing visual noise [env: ACCESSIBLE=]
   -H, --hidden               Ignore hidden files
   -q, --quiet                Silence output

--- a/tests/snapshots/ui__ui_test_usage_help_flag-2.snap
+++ b/tests/snapshots/ui__ui_test_usage_help_flag-2.snap
@@ -22,6 +22,6 @@ Options:
   -g, --gitignore            Ignores files matched by git's ignore files
   -f, --format <FORMAT>      Specify the format of the archive
   -p, --password <PASSWORD>  decompress or list with password
-  -c, --threads <THREADS>    cocurrent working threads
+  -c, --threads <THREADS>    concurrent working threads
   -h, --help                 Print help (see more with '--help')
   -V, --version              Print version

--- a/tests/snapshots/ui__ui_test_usage_help_flag.snap
+++ b/tests/snapshots/ui__ui_test_usage_help_flag.snap
@@ -19,10 +19,10 @@ Commands:
 
 Options:
   -y, --yes
-          Skip [Y/n] questions positively
+          Skip [Y/n] questions, default to yes
 
   -n, --no
-          Skip [Y/n] questions negatively
+          Skip [Y/n] questions, default to no
 
   -A, --accessible
           Activate accessibility mode, reducing visual noise

--- a/tests/snapshots/ui__ui_test_usage_help_flag.snap
+++ b/tests/snapshots/ui__ui_test_usage_help_flag.snap
@@ -45,7 +45,7 @@ Options:
           decompress or list with password
 
   -c, --threads <THREADS>
-          cocurrent working threads
+          concurrent working threads
 
   -h, --help
           Print help (see a summary with '-h')

--- a/tests/snapshots/ui__ui_test_usage_help_flag.snap
+++ b/tests/snapshots/ui__ui_test_usage_help_flag.snap
@@ -30,22 +30,22 @@ Options:
           [env: ACCESSIBLE=]
 
   -H, --hidden
-          Ignores hidden files
+          Ignore hidden files
 
   -q, --quiet
-          Silences output
+          Silence output
 
   -g, --gitignore
-          Ignores files matched by git's ignore files
+          Ignore files matched by git's ignore files
 
   -f, --format <FORMAT>
           Specify the format of the archive
 
   -p, --password <PASSWORD>
-          decompress or list with password
+          Decompress or list with password
 
   -c, --threads <THREADS>
-          concurrent working threads
+          Concurrent working threads
 
   -h, --help
           Print help (see a summary with '-h')


### PR DESCRIPTION
Just saw a typo in the CLI help, so I thought I'd have a look and fix it. Along the way I also rewrote some of the other texts. It's all in separate commits, feel free to pick and choose :)