### PR TITLE
feat: Add rename option in overwrite menu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ test-strategy = "0.4.0"
 default = ["use_zlib", "use_zstd_thin", "unrar"]
 use_zlib = ["flate2/zlib", "gzp/deflate_zlib", "zip/deflate-zlib"]
 use_zstd_thin = ["zstd/thin"]
+allow_piped_choice = []
 
 # For generating binaries for releases
 [profile.release]

--- a/src/commands/decompress.rs
+++ b/src/commands/decompress.rs
@@ -14,7 +14,11 @@ use crate::{
         Extension,
     },
     utils::{
-        self, io::lock_and_flush_output_stdio, is_path_stdin, logger::{info, info_accessible}, nice_directory_display, user_wants_to_continue
+        self,
+        io::lock_and_flush_output_stdio,
+        is_path_stdin,
+        logger::{info, info_accessible},
+        nice_directory_display, user_wants_to_continue,
     },
     QuestionAction, QuestionPolicy, BUFFER_CAPACITY,
 };

--- a/src/commands/decompress.rs
+++ b/src/commands/decompress.rs
@@ -323,6 +323,8 @@ fn smart_unpack(
         (temp_dir_path.to_owned(), output_file_path.to_owned())
     };
 
+    // Before moving, need to check if a file with the same name already exists
+    // If it does, need to ask the user what to do
     new_path = match utils::resolve_path(&new_path, question_policy)? {
         Some(path) => path,
         None => return Ok(ControlFlow::Break(())),

--- a/src/commands/decompress.rs
+++ b/src/commands/decompress.rs
@@ -325,7 +325,7 @@ fn smart_unpack(
 
     // Before moving, need to check if a file with the same name already exists
     // If it does, need to ask the user what to do
-    new_path = match utils::resolve_path(&new_path, question_policy)? {
+    new_path = match utils::resolve_path_conflict(&new_path, question_policy)? {
         Some(path) => path,
         None => return Ok(ControlFlow::Break(())),
     };

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -8,7 +8,7 @@ use std::{
 
 use fs_err as fs;
 
-use super::user_wants_to_overwrite;
+use super::{question::FileConflitOperation, user_wants_to_overwrite};
 use crate::{
     extension::Extension,
     utils::{logger::info_accessible, EscapedPathDisplay},

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -19,20 +19,6 @@ pub fn is_path_stdin(path: &Path) -> bool {
     path.as_os_str() == "-"
 }
 
-/// Remove `path` asking the user to overwrite if necessary.
-///
-/// * `Ok(true)` means the path is clear,
-/// * `Ok(false)` means the user doesn't want to overwrite
-/// * `Err(_)` is an error
-pub fn clear_path(path: &Path, question_policy: QuestionPolicy) -> crate::Result<bool> {
-    if path.exists() && !user_wants_to_overwrite(path, question_policy)? {
-        return Ok(false);
-    }
-
-    remove_file_or_dir(path)?;
-
-    Ok(true)
-}
 
 pub fn resolve_path(path: &Path, question_policy: QuestionPolicy) -> crate::Result<Option<PathBuf>> {
     if path.exists() {

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -34,6 +34,24 @@ pub fn clear_path(path: &Path, question_policy: QuestionPolicy) -> crate::Result
     Ok(true)
 }
 
+pub fn resolve_path(path: &Path, question_policy: QuestionPolicy) -> crate::Result<Option<PathBuf>> {
+    if path.exists() {
+        match user_wants_to_overwrite(path, question_policy)? {
+            FileConflitOperation::Cancel => return Ok(None),
+            FileConflitOperation::Overwrite => {
+                remove_file_or_dir(path)?;
+                Ok(Some(path.to_path_buf()))
+            },
+            FileConflitOperation::Rename => {
+                let renamed_path = rename_for_available_filename(path);
+                Ok(Some(renamed_path))
+            },
+        }
+    } else {
+        Ok(Some(path.to_path_buf()))
+    }
+}
+
 pub fn remove_file_or_dir(path: &Path) -> crate::Result<()> {
     if path.is_dir() {
         fs::remove_dir_all(path)?;

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -22,7 +22,7 @@ pub fn is_path_stdin(path: &Path) -> bool {
 /// Check if &Path exists, if it does then ask the user if they want to overwrite or rename it.
 /// If the user want to overwrite then the file or directory will be removed and returned the same input path
 /// If the user want to rename then nothing will be removed and a new path will be returned with a new name
-/// 
+///
 /// * `Ok(None)` means the user wants to cancel the operation
 /// * `Ok(Some(path))` returns a valid PathBuf without any another file or directory with the same name
 /// * `Err(_)` is an error

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -19,7 +19,13 @@ pub fn is_path_stdin(path: &Path) -> bool {
     path.as_os_str() == "-"
 }
 
-/// Check if &Path exists, if it does then ask the user if they want to overwrite or rename it
+/// Check if &Path exists, if it does then ask the user if they want to overwrite or rename it.
+/// If the user want to overwrite then the file or directory will be removed and returned the same input path
+/// If the user want to rename then nothing will be removed and a new path will be returned with a new name
+/// 
+/// * `Ok(None)` means the user wants to cancel the operation
+/// * `Ok(Some(path))` returns a valid PathBuf without any another file or directory with the same name
+/// * `Err(_)` is an error
 pub fn resolve_path_conflict(path: &Path, question_policy: QuestionPolicy) -> crate::Result<Option<PathBuf>> {
     if path.exists() {
         match user_wants_to_overwrite(path, question_policy)? {

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -19,19 +19,18 @@ pub fn is_path_stdin(path: &Path) -> bool {
     path.as_os_str() == "-"
 }
 
-
 pub fn resolve_path(path: &Path, question_policy: QuestionPolicy) -> crate::Result<Option<PathBuf>> {
     if path.exists() {
         match user_wants_to_overwrite(path, question_policy)? {
-            FileConflitOperation::Cancel => return Ok(None),
+            FileConflitOperation::Cancel => Ok(None),
             FileConflitOperation::Overwrite => {
                 remove_file_or_dir(path)?;
                 Ok(Some(path.to_path_buf()))
-            },
+            }
             FileConflitOperation::Rename => {
                 let renamed_path = rename_for_available_filename(path);
                 Ok(Some(renamed_path))
-            },
+            }
         }
     } else {
         Ok(Some(path.to_path_buf()))
@@ -64,10 +63,10 @@ pub fn rename_or_increment_filename(path: &Path) -> PathBuf {
         Some((base, number_str)) if number_str.chars().all(char::is_numeric) => {
             let number = number_str.parse::<u32>().unwrap_or(0);
             format!("{}_{}", base, number + 1)
-        },
+        }
         _ => format!("{}_1", filename),
     };
-    
+
     let mut new_path = parent.join(new_filename);
     if !extension.is_empty() {
         new_path.set_extension(extension);

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -19,6 +19,7 @@ pub fn is_path_stdin(path: &Path) -> bool {
     path.as_os_str() == "-"
 }
 
+/// Check if &Path exists, if it does then ask the user if they want to overwrite or rename it
 pub fn resolve_path(path: &Path, question_policy: QuestionPolicy) -> crate::Result<Option<PathBuf>> {
     if path.exists() {
         match user_wants_to_overwrite(path, question_policy)? {
@@ -46,6 +47,7 @@ pub fn remove_file_or_dir(path: &Path) -> crate::Result<()> {
     Ok(())
 }
 
+/// Create a new path renaming the "filename" from &Path until find a free name
 pub fn rename_for_available_filename(path: &Path) -> PathBuf {
     let mut renamed_path = rename_or_increment_filename(path);
     while renamed_path.exists() {
@@ -54,6 +56,8 @@ pub fn rename_for_available_filename(path: &Path) -> PathBuf {
     renamed_path
 }
 
+/// Create a new path renaming the "filename" from &Path to `filename_1`
+/// or `filename_2`, `filename_3` until find a free name
 pub fn rename_or_increment_filename(path: &Path) -> PathBuf {
     let parent = path.parent().unwrap_or_else(|| Path::new(""));
     let filename = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -53,7 +53,7 @@ pub fn remove_file_or_dir(path: &Path) -> crate::Result<()> {
     Ok(())
 }
 
-/// Create a new path renaming the "filename" from &Path until find a free name
+/// Create a new path renaming the "filename" from &Path for a available name in the same directory
 pub fn rename_for_available_filename(path: &Path) -> PathBuf {
     let mut renamed_path = rename_or_increment_filename(path);
     while renamed_path.exists() {
@@ -63,7 +63,10 @@ pub fn rename_for_available_filename(path: &Path) -> PathBuf {
 }
 
 /// Create a new path renaming the "filename" from &Path to `filename_1`
-/// or `filename_2`, `filename_3` until find a free name
+/// if its name already ends with `_` and some number, then it increments the number
+/// Example:
+/// - `file.txt` -> `file_1.txt`
+/// - `file_1.txt` -> `file_2.txt`
 pub fn rename_or_increment_filename(path: &Path) -> PathBuf {
     let parent = path.parent().unwrap_or_else(|| Path::new(""));
     let filename = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -20,7 +20,7 @@ pub fn is_path_stdin(path: &Path) -> bool {
 }
 
 /// Check if &Path exists, if it does then ask the user if they want to overwrite or rename it
-pub fn resolve_path(path: &Path, question_policy: QuestionPolicy) -> crate::Result<Option<PathBuf>> {
+pub fn resolve_path_conflict(path: &Path, question_policy: QuestionPolicy) -> crate::Result<Option<PathBuf>> {
     if path.exists() {
         match user_wants_to_overwrite(path, question_policy)? {
             FileConflitOperation::Cancel => Ok(None),

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -18,10 +18,13 @@ pub use self::{
         EscapedPathDisplay,
     },
     fs::{
-        cd_into_same_dir_as, resolve_path, create_dir_if_non_existent, is_path_stdin, remove_file_or_dir,
-        try_infer_extension, rename_for_available_filename
+        cd_into_same_dir_as, create_dir_if_non_existent, is_path_stdin, remove_file_or_dir,
+        rename_for_available_filename, resolve_path, try_infer_extension,
     },
-    question::{ask_to_create_file, user_wants_to_continue, user_wants_to_overwrite, FileConflitOperation, QuestionAction, QuestionPolicy},
+    question::{
+        ask_to_create_file, user_wants_to_continue, user_wants_to_overwrite, FileConflitOperation, QuestionAction,
+        QuestionPolicy,
+    },
     utf8::{get_invalid_utf8_paths, is_invalid_utf8},
 };
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -19,7 +19,7 @@ pub use self::{
     },
     fs::{
         cd_into_same_dir_as, clear_path, create_dir_if_non_existent, is_path_stdin, remove_file_or_dir,
-        try_infer_extension,
+        try_infer_extension, rename_for_available_filename
     },
     question::{ask_to_create_file, user_wants_to_continue, user_wants_to_overwrite, QuestionAction, QuestionPolicy},
     utf8::{get_invalid_utf8_paths, is_invalid_utf8},

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -19,7 +19,7 @@ pub use self::{
     },
     fs::{
         cd_into_same_dir_as, create_dir_if_non_existent, is_path_stdin, remove_file_or_dir,
-        rename_for_available_filename, resolve_path, try_infer_extension,
+        rename_for_available_filename, resolve_path_conflict, try_infer_extension,
     },
     question::{
         ask_to_create_file, user_wants_to_continue, user_wants_to_overwrite, FileConflitOperation, QuestionAction,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -18,10 +18,10 @@ pub use self::{
         EscapedPathDisplay,
     },
     fs::{
-        cd_into_same_dir_as, clear_path, create_dir_if_non_existent, is_path_stdin, remove_file_or_dir,
+        cd_into_same_dir_as, resolve_path, create_dir_if_non_existent, is_path_stdin, remove_file_or_dir,
         try_infer_extension, rename_for_available_filename
     },
-    question::{ask_to_create_file, user_wants_to_continue, user_wants_to_overwrite, QuestionAction, QuestionPolicy},
+    question::{ask_to_create_file, user_wants_to_continue, user_wants_to_overwrite, FileConflitOperation, QuestionAction, QuestionPolicy},
     utf8::{get_invalid_utf8_paths, is_invalid_utf8},
 };
 

--- a/src/utils/question.rs
+++ b/src/utils/question.rs
@@ -45,7 +45,7 @@ pub enum FileConflitOperation {
     Cancel,
     /// Overwrite the existing file with the new one
     Overwrite,
-    /// Rename the file 
+    /// Rename the file
     /// It'll be put "_1" at the end of the filename or "_2","_3","_4".. if already exists
     Rename,
 }
@@ -223,10 +223,7 @@ impl<'a, T: Default> ChoicePrompt<'a, T> {
             answer.make_ascii_lowercase();
             let answer = answer.trim();
 
-            let chosen_index = self
-                .choises
-                .iter()
-                .position(|choise| choise.label.starts_with(answer));
+            let chosen_index = self.choises.iter().position(|choise| choise.label.starts_with(answer));
 
             if let Some(i) = chosen_index {
                 return Ok(self.choises.remove(i).value);

--- a/src/utils/question.rs
+++ b/src/utils/question.rs
@@ -78,17 +78,24 @@ pub fn user_wants_to_continue(
         QuestionPolicy::AlwaysYes => Ok(true),
         QuestionPolicy::AlwaysNo => Ok(false),
         QuestionPolicy::Ask => {
+            let path = path_to_str(strip_cur_dir(path));
             let action = match question_action {
                 QuestionAction::Compression => "compress",
                 QuestionAction::Decompression => "decompress",
             };
-            let path = path_to_str(strip_cur_dir(path));
-            let path = Some(&*path);
-            let placeholder = Some("FILE");
-            Confirmation::new(&format!("Do you want to {action} 'FILE'?"), placeholder).ask(path)
+
+            ChoicePrompt::new(
+                format!("Do you want to {action} {path}?"),
+                [
+                    ("yes", true, *colors::GREEN),
+                    ("no", false, *colors::RED),
+                ],
+            )
+            .ask()
         }
     }
 }
+
 
 /// Choise dialog for end user with [option1/option2/...] question.
 ///

--- a/src/utils/question.rs
+++ b/src/utils/question.rs
@@ -56,7 +56,6 @@ pub fn user_wants_to_overwrite(path: &Path, question_policy: QuestionPolicy) -> 
     }
 }
 
-
 /// Check if QuestionPolicy flags were set, otherwise, ask user if they want to overwrite.
 pub fn ask_file_conflict_operation(path: &Path) -> Result<FileConflitOperation> {
     use FileConflitOperation as Op;
@@ -90,12 +89,12 @@ pub fn ask_to_create_file(path: &Path, question_policy: QuestionPolicy) -> Resul
                 FileConflitOperation::Overwrite => {
                     utils::remove_file_or_dir(path)?;
                     Ok(Some(fs::File::create(path)?))
-                },
+                }
                 FileConflitOperation::Cancel => Ok(None),
                 FileConflitOperation::Rename => {
                     let renamed_file_path = utils::rename_for_available_filename(path);
                     Ok(Some(fs::File::create(renamed_file_path)?))
-                },
+                }
             }
         }
         Err(e) => Err(Error::from(e)),
@@ -120,16 +119,12 @@ pub fn user_wants_to_continue(
 
             ChoicePrompt::new(
                 format!("Do you want to {action} {path}?"),
-                [
-                    ("yes", true, *colors::GREEN),
-                    ("no", false, *colors::RED),
-                ],
+                [("yes", true, *colors::GREEN), ("no", false, *colors::RED)],
             )
             .ask()
         }
     }
 }
-
 
 /// Choise dialog for end user with [option1/option2/...] question.
 ///
@@ -176,25 +171,33 @@ impl<'a, T: Default> ChoicePrompt<'a, T> {
         // Ask the same question to end while no valid answers are given
         loop {
             let choice_prompt = if is_running_in_accessible_mode() {
-                self
-                    .choises
+                self.choises
                     .iter()
                     .map(|choise| format!("{}{}{}", choise.color, choise.label, *colors::RESET))
                     .collect::<Vec<_>>()
-                    .join("/") 
+                    .join("/")
             } else {
                 let choises = self
                     .choises
                     .iter()
-                    .map(|choise| format!("{}{}{}", choise.color, choise.label.chars().nth(0).expect("dev error"), *colors::RESET))
+                    .map(|choise| {
+                        format!(
+                            "{}{}{}",
+                            choise.color,
+                            choise
+                                .label
+                                .chars()
+                                .nth(0)
+                                .expect("dev error, should be reported, we checked this won't happen"),
+                            *colors::RESET
+                        )
+                    })
                     .collect::<Vec<_>>()
                     .join("/");
 
                 format!("[{}]", choises)
             };
 
-
-            // TODO: use accessible mode
             eprintln!("{} {}", message, choice_prompt);
 
             let mut answer = String::new();
@@ -213,12 +216,12 @@ impl<'a, T: Default> ChoicePrompt<'a, T> {
             answer.make_ascii_lowercase();
             let answer = answer.trim();
 
-            let choosed_index = self
+            let chosen_index = self
                 .choises
                 .iter()
                 .position(|choise| answer == &choise.label[0..answer.len()]);
 
-            if let Some(i) = choosed_index {
+            if let Some(i) = chosen_index {
                 return Ok(self.choises.remove(i).value);
             }
         }

--- a/src/utils/question.rs
+++ b/src/utils/question.rs
@@ -177,12 +177,24 @@ impl<'a, T: Default> ChoicePrompt<'a, T> {
 
         // Ask the same question to end while no valid answers are given
         loop {
-            let choice_prompt = self
-                .choises
-                .iter()
-                .map(|choise| format!("{}{}{}", choise.color, choise.label, *colors::RESET))
-                .collect::<Vec<_>>()
-                .join("/");
+            let choice_prompt = if is_running_in_accessible_mode() {
+                self
+                    .choises
+                    .iter()
+                    .map(|choise| format!("{}{}{}", choise.color, choise.label, *colors::RESET))
+                    .collect::<Vec<_>>()
+                    .join("/") 
+            } else {
+                let choises = self
+                    .choises
+                    .iter()
+                    .map(|choise| format!("{}{}{}", choise.color, choise.label.chars().nth(0).expect("dev error"), *colors::RESET))
+                    .collect::<Vec<_>>()
+                    .join("/");
+
+                format!("[{}]", choises)
+            };
+
 
             // TODO: use accessible mode
             eprintln!("{} {}", message, choice_prompt);

--- a/src/utils/question.rs
+++ b/src/utils/question.rs
@@ -46,16 +46,13 @@ pub enum FileConflitOperation {
 }
 
 /// Check if QuestionPolicy flags were set, otherwise, ask user if they want to overwrite.
-pub fn user_wants_to_overwrite(path: &Path, question_policy: QuestionPolicy) -> crate::Result<bool> {
+pub fn user_wants_to_overwrite(path: &Path, question_policy: QuestionPolicy) -> crate::Result<FileConflitOperation> {
+    use FileConflitOperation as Op;
+
     match question_policy {
-        QuestionPolicy::AlwaysYes => Ok(true),
-        QuestionPolicy::AlwaysNo => Ok(false),
-        QuestionPolicy::Ask => {
-            let path = path_to_str(strip_cur_dir(path));
-            let path = Some(&*path);
-            let placeholder = Some("FILE");
-            Confirmation::new("Do you want to overwrite 'FILE'?", placeholder).ask(path)
-        }
+        QuestionPolicy::AlwaysYes => Ok(Op::Overwrite),
+        QuestionPolicy::AlwaysNo => Ok(Op::Cancel),
+        QuestionPolicy::Ask => ask_file_conflict_operation(path),
     }
 }
 

--- a/src/utils/question.rs
+++ b/src/utils/question.rs
@@ -116,17 +116,14 @@ pub fn user_wants_to_continue(
         QuestionPolicy::AlwaysYes => Ok(true),
         QuestionPolicy::AlwaysNo => Ok(false),
         QuestionPolicy::Ask => {
-            let path = path_to_str(strip_cur_dir(path));
             let action = match question_action {
                 QuestionAction::Compression => "compress",
                 QuestionAction::Decompression => "decompress",
             };
-
-            ChoicePrompt::new(
-                format!("Do you want to {action} {path}?"),
-                [("yes", true, *colors::GREEN), ("no", false, *colors::RED)],
-            )
-            .ask()
+            let path = path_to_str(strip_cur_dir(path));
+            let path = Some(&*path);
+            let placeholder = Some("FILE");
+            Confirmation::new(&format!("Do you want to {action} 'FILE'?"), placeholder).ask(path)
         }
     }
 }

--- a/src/utils/question.rs
+++ b/src/utils/question.rs
@@ -96,7 +96,8 @@ pub fn ask_to_create_file(path: &Path, question_policy: QuestionPolicy) -> Resul
                 },
                 FileConflitOperation::Cancel => Ok(None),
                 FileConflitOperation::Rename => {
-                    todo!()
+                    let renamed_file_path = utils::rename_for_available_filename(path);
+                    Ok(Some(fs::File::create(renamed_file_path)?))
                 },
             }
         }

--- a/src/utils/question.rs
+++ b/src/utils/question.rs
@@ -297,7 +297,7 @@ impl<'a> Confirmation<'a> {
                 let error = FinalError::with_title("Unexpected EOF when asking question.")
                     .detail("When asking the user:")
                     .detail(format!("  \"{message}\""))
-                    .detail("Expected 'y' or 'n' as answer, but found EOF instead.")
+                    .detail("Expected one of the options as answer, but found EOF instead.")
                     .hint("If using Ouch in scripting, consider using `--yes` and `--no`.");
 
                 return Err(error.into());

--- a/src/utils/question.rs
+++ b/src/utils/question.rs
@@ -226,7 +226,7 @@ impl<'a, T: Default> ChoicePrompt<'a, T> {
             let chosen_index = self
                 .choises
                 .iter()
-                .position(|choise| answer == &choise.label[0..answer.len()]);
+                .position(|choise| choise.label.starts_with(answer));
 
             if let Some(i) = chosen_index {
                 return Ok(self.choises.remove(i).value);

--- a/src/utils/question.rs
+++ b/src/utils/question.rs
@@ -134,7 +134,7 @@ pub fn user_wants_to_continue(
 /// Choise dialog for end user with [option1/option2/...] question.
 /// Each option is a [Choice] entity, holding a value "T" returned when that option is selected
 pub struct ChoicePrompt<'a, T: Default> {
-    /// The message to be displayed with the placeholder text in it.
+    /// The message to be displayed before the options
     /// e.g.: "Do you want to overwrite 'FILE'?"
     pub prompt: String,
 

--- a/src/utils/question.rs
+++ b/src/utils/question.rs
@@ -38,10 +38,15 @@ pub enum QuestionAction {
 }
 
 #[derive(Default)]
+/// Determines which action to do when there is a file conflict
 pub enum FileConflitOperation {
     #[default]
+    /// Cancel the operation
     Cancel,
+    /// Overwrite the existing file with the new one
     Overwrite,
+    /// Rename the file 
+    /// It'll be put "_1" at the end of the filename or "_2","_3","_4".. if already exists
     Rename,
 }
 
@@ -56,7 +61,7 @@ pub fn user_wants_to_overwrite(path: &Path, question_policy: QuestionPolicy) -> 
     }
 }
 
-/// Check if QuestionPolicy flags were set, otherwise, ask user if they want to overwrite.
+/// Ask the user if they want to overwrite or rename the &Path
 pub fn ask_file_conflict_operation(path: &Path) -> Result<FileConflitOperation> {
     use FileConflitOperation as Op;
 
@@ -127,8 +132,7 @@ pub fn user_wants_to_continue(
 }
 
 /// Choise dialog for end user with [option1/option2/...] question.
-///
-/// If the placeholder is found in the prompt text, it will be replaced to form the final message.
+/// Each option is a [Choice] entity, holding a value "T" returned when that option is selected
 pub struct ChoicePrompt<'a, T: Default> {
     /// The message to be displayed with the placeholder text in it.
     /// e.g.: "Do you want to overwrite 'FILE'?"
@@ -137,6 +141,8 @@ pub struct ChoicePrompt<'a, T: Default> {
     pub choises: Vec<Choice<'a, T>>,
 }
 
+/// A single choice showed as a option to user in a [ChoicePrompt]
+/// It holds a label and a color to display to user and a real value to be returned
 pub struct Choice<'a, T: Default> {
     label: &'a str,
     value: T,
@@ -155,7 +161,8 @@ impl<'a, T: Default> ChoicePrompt<'a, T> {
         }
     }
 
-    /// Creates user message and receives a boolean input to be used on the program
+    /// Creates user message and receives a input to be compared with choises "label"
+    /// and returning the real value of the choise selected
     pub fn ask(mut self) -> crate::Result<T> {
         let message = self.prompt;
 

--- a/src/utils/question.rs
+++ b/src/utils/question.rs
@@ -163,6 +163,7 @@ impl<'a, T: Default> ChoicePrompt<'a, T> {
     pub fn ask(mut self) -> crate::Result<T> {
         let message = self.prompt;
 
+        #[cfg(not(feature = "allow_piped_choice"))]
         if !stdin().is_terminal() {
             eprintln!("{}", message);
             eprintln!("Pass --yes to proceed");
@@ -259,6 +260,7 @@ impl<'a> Confirmation<'a> {
             (Some(placeholder), Some(subs)) => Cow::Owned(self.prompt.replace(placeholder, subs)),
         };
 
+        #[cfg(not(feature = "allow_piped_choice"))]
         if !stdin().is_terminal() {
             eprintln!("{}", message);
             eprintln!("Pass --yes to proceed");

--- a/src/utils/question.rs
+++ b/src/utils/question.rs
@@ -211,7 +211,7 @@ impl<'a, T: Default> ChoicePrompt<'a, T> {
                 let error = FinalError::with_title("Unexpected EOF when asking question.")
                     .detail("When asking the user:")
                     .detail(format!("  \"{message}\""))
-                    .detail("Expected 'y' or 'n' as answer, but found EOF instead.")
+                    .detail("Expected one of the options as answer, but found EOF instead.")
                     .hint("If using Ouch in scripting, consider using `--yes` and `--no`.");
 
                 return Err(error.into());
@@ -297,7 +297,7 @@ impl<'a> Confirmation<'a> {
                 let error = FinalError::with_title("Unexpected EOF when asking question.")
                     .detail("When asking the user:")
                     .detail(format!("  \"{message}\""))
-                    .detail("Expected one of the options as answer, but found EOF instead.")
+                    .detail("Expected 'y' or 'n' as answer, but found EOF instead.")
                     .hint("If using Ouch in scripting, consider using `--yes` and `--no`.");
 
                 return Err(error.into());

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -194,6 +194,83 @@ fn multiple_files(
     assert_same_directory(before, after, !matches!(ext, DirectoryExtension::Zip));
 }
 
+#[proptest(cases = 25)]
+fn multiple_files_with_conflict_and_choce_to_overwrite(
+    ext: DirectoryExtension,
+    #[any(size_range(0..1).lift())] extra_extensions: Vec<FileExtension>,
+    #[strategy(0u8..3)] depth: u8,
+) {
+    let dir = tempdir().unwrap();
+    let dir = dir.path();
+
+    let before = &dir.join("before");
+    let before_dir = &before.join("dir");
+    fs::create_dir_all(before_dir).unwrap();
+    create_random_files(before_dir, depth, &mut SmallRng::from_entropy());
+    
+    let after = &dir.join("after");
+    let after_dir = &after.join("dir");
+    fs::create_dir_all(after_dir).unwrap();
+    create_random_files(after_dir, depth, &mut SmallRng::from_entropy());
+    
+    let archive = &dir.join(format!("archive.{}", merge_extensions(&ext, extra_extensions)));
+    ouch!("-A", "c", before_dir, archive);
+
+    crate::utils::cargo_bin()
+        .arg("decompress")
+        .arg(archive)
+        .arg("-d")
+        .arg(after)
+        .arg("--yes")
+        //.write_stdin("y")
+        .assert()
+        .success();
+
+    assert_same_directory(before, after, false);
+}
+
+#[proptest(cases = 25)]
+fn multiple_files_with_conflict_and_choce_to_not_overwrite(
+    ext: DirectoryExtension,
+    #[any(size_range(0..1).lift())] extra_extensions: Vec<FileExtension>,
+    #[strategy(0u8..3)] depth: u8,
+) {
+    let dir = tempdir().unwrap();
+    let dir = dir.path();
+
+    let before = &dir.join("before");
+    let before_dir = &before.join("dir");
+    fs::create_dir_all(before_dir).unwrap();
+    create_random_files(before_dir, depth, &mut SmallRng::from_entropy());
+    
+    let after = &dir.join("after");
+    let after_dir = &after.join("dir");
+    fs::create_dir_all(after_dir).unwrap();
+    
+    let after_backup = &dir.join("after_backup");
+    let after_backup_dir = &after_backup.join("dir");
+    fs::create_dir_all(after_backup_dir).unwrap();
+
+    // Create a file with the same name as one of the files in the after directory
+    fs::write(after_dir.join("something.txt"), "Some content").unwrap();
+    fs::copy(after_dir.join("something.txt"), after_backup_dir.join("something.txt")).unwrap();
+    
+    let archive = &dir.join(format!("archive.{}", merge_extensions(&ext, extra_extensions)));
+    ouch!("-A", "c", before_dir, archive);
+
+    crate::utils::cargo_bin()
+        .arg("decompress")
+        .arg(archive)
+        .arg("-d")
+        .arg(after)
+        .arg("--no")
+        .assert()
+        .success();
+
+    assert_same_directory(after, after_backup, false);
+}
+
+
 #[cfg(feature = "unrar")]
 #[test]
 fn unpack_rar() -> Result<(), Box<dyn std::error::Error>> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -270,6 +270,43 @@ fn multiple_files_with_conflict_and_choce_to_not_overwrite(
     assert_same_directory(after, after_backup, false);
 }
 
+#[cfg(feature = "allow_piped_choice")]
+#[proptest(cases = 25)]
+fn multiple_files_with_conflict_and_choce_to_rename(
+    ext: DirectoryExtension,
+    #[any(size_range(0..1).lift())] extra_extensions: Vec<FileExtension>,
+    #[strategy(0u8..3)] depth: u8,
+) {
+    let dir = tempdir().unwrap();
+    let dir = dir.path();
+
+    let before = &dir.join("before");
+    let before_dir = &before.join("dir");
+    fs::create_dir_all(before_dir).unwrap();
+    create_random_files(before_dir, depth, &mut SmallRng::from_entropy());
+    
+    let after = &dir.join("after");
+    let after_dir = &after.join("dir");
+    fs::create_dir_all(after_dir).unwrap();
+    create_random_files(after_dir, depth, &mut SmallRng::from_entropy());
+    
+    let archive = &dir.join(format!("archive.{}", merge_extensions(&ext, extra_extensions)));
+    ouch!("-A", "c", before_dir, archive);
+
+    let after_renamed_dir = &after.join("dir_1");
+    assert_eq!(false, after_renamed_dir.exists());
+
+    crate::utils::cargo_bin()
+        .arg("decompress")
+        .arg(archive)
+        .arg("-d")
+        .arg(after)
+        .write_stdin("r")
+        .assert()
+        .success();
+
+    assert_same_directory(before_dir, after_renamed_dir, false);
+}
 
 #[cfg(feature = "unrar")]
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -207,12 +207,12 @@ fn multiple_files_with_conflict_and_choce_to_overwrite(
     let before_dir = &before.join("dir");
     fs::create_dir_all(before_dir).unwrap();
     create_random_files(before_dir, depth, &mut SmallRng::from_entropy());
-    
+
     let after = &dir.join("after");
     let after_dir = &after.join("dir");
     fs::create_dir_all(after_dir).unwrap();
     create_random_files(after_dir, depth, &mut SmallRng::from_entropy());
-    
+
     let archive = &dir.join(format!("archive.{}", merge_extensions(&ext, extra_extensions)));
     ouch!("-A", "c", before_dir, archive);
 
@@ -242,11 +242,11 @@ fn multiple_files_with_conflict_and_choce_to_not_overwrite(
     let before_dir = &before.join("dir");
     fs::create_dir_all(before_dir).unwrap();
     create_random_files(before_dir, depth, &mut SmallRng::from_entropy());
-    
+
     let after = &dir.join("after");
     let after_dir = &after.join("dir");
     fs::create_dir_all(after_dir).unwrap();
-    
+
     let after_backup = &dir.join("after_backup");
     let after_backup_dir = &after_backup.join("dir");
     fs::create_dir_all(after_backup_dir).unwrap();
@@ -254,7 +254,7 @@ fn multiple_files_with_conflict_and_choce_to_not_overwrite(
     // Create a file with the same name as one of the files in the after directory
     fs::write(after_dir.join("something.txt"), "Some content").unwrap();
     fs::copy(after_dir.join("something.txt"), after_backup_dir.join("something.txt")).unwrap();
-    
+
     let archive = &dir.join(format!("archive.{}", merge_extensions(&ext, extra_extensions)));
     ouch!("-A", "c", before_dir, archive);
 
@@ -284,12 +284,12 @@ fn multiple_files_with_conflict_and_choce_to_rename(
     let before_dir = &before.join("dir");
     fs::create_dir_all(before_dir).unwrap();
     create_random_files(before_dir, depth, &mut SmallRng::from_entropy());
-    
+
     let after = &dir.join("after");
     let after_dir = &after.join("dir");
     fs::create_dir_all(after_dir).unwrap();
     create_random_files(after_dir, depth, &mut SmallRng::from_entropy());
-    
+
     let archive = &dir.join(format!("archive.{}", merge_extensions(&ext, extra_extensions)));
     ouch!("-A", "c", before_dir, archive);
 


### PR DESCRIPTION
Closes #767 


## Examples

> Setup
> ```sh
> echo '...' > something.txt
> ouch compress something.txt something.zip
> ```

* Basic example:
![image](https://github.com/user-attachments/assets/6e7cc9fe-7c9d-4581-a0b5-2086b0b057be)

* Accessible mode:
![image](https://github.com/user-attachments/assets/894c5fca-0204-441c-b5c4-aa270a543539)

* Auto increment the final number when there are another conflict in renamed name
![image](https://github.com/user-attachments/assets/61e41bc9-4293-49e4-8b75-1d527d310f5d)

