### PR TITLE
chore: Disable smart unpack when `--dir` is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Categories Used:
 - Support decompression  over stdin [\#692](https://github.com/ouch-org/ouch/pull/692) ([rcorre](https://github.com/rcorre))
 - Make `--format` more forgiving with the formatting of the provided format [\#519](https://github.com/ouch-org/ouch/pull/519) ([marcospb19](https://github.com/marcospb19))
 - Use buffered writer for list output [\#764](https://github.com/ouch-org/ouch/pull/764) ([killercup](https://github.com/killercup))
+- Disable smart unpack when `--dir` flag is provided in decompress command [\#782](https://github.com/ouch-org/ouch/pull/782) ([talis-fb](https://github.com/talis-fb))
 
 ## [0.5.1](https://github.com/ouch-org/ouch/compare/0.5.0...0.5.1)
 

--- a/src/commands/decompress.rs
+++ b/src/commands/decompress.rs
@@ -313,7 +313,7 @@ fn unpack(
     output_dir: &Path,
     question_policy: QuestionPolicy,
 ) -> crate::Result<ControlFlow<(), usize>> {
-    let is_valid_output_dir = !output_dir.exists() || (output_dir.is_dir() && output_dir.read_dir()?.count() > 0);
+    let is_valid_output_dir = !output_dir.exists() || (output_dir.is_dir() && output_dir.read_dir()?.count() == 0);
 
     let output_dir_cleaned = if is_valid_output_dir {
         output_dir.to_owned()

--- a/src/commands/decompress.rs
+++ b/src/commands/decompress.rs
@@ -318,7 +318,7 @@ fn unpack(
     let output_dir_cleaned = if is_valid_output_dir {
         output_dir.to_owned()
     } else {
-        match utils::resolve_path_conflict(&output_dir, question_policy)? {
+        match utils::resolve_path_conflict(output_dir, question_policy)? {
             Some(path) => path,
             None => return Ok(ControlFlow::Break(())),
         }

--- a/src/commands/decompress.rs
+++ b/src/commands/decompress.rs
@@ -31,7 +31,7 @@ pub struct DecompressOptions<'a> {
     pub formats: Vec<Extension>,
     pub output_dir: &'a Path,
     pub output_file_path: PathBuf,
-    pub is_output_dir_explicit: bool,
+    pub is_output_dir_provided: bool,
     pub question_policy: QuestionPolicy,
     pub quiet: bool,
     pub password: Option<&'a [u8]>,
@@ -74,7 +74,7 @@ pub fn decompress_file(options: DecompressOptions) -> crate::Result<()> {
             options.output_dir,
             &options.output_file_path,
             options.question_policy,
-            options.is_output_dir_explicit,
+            options.is_output_dir_provided,
         )? {
             files
         } else {
@@ -152,7 +152,7 @@ pub fn decompress_file(options: DecompressOptions) -> crate::Result<()> {
                 options.output_dir,
                 &options.output_file_path,
                 options.question_policy,
-                options.is_output_dir_explicit,
+                options.is_output_dir_provided,
             )? {
                 files
             } else {
@@ -186,7 +186,7 @@ pub fn decompress_file(options: DecompressOptions) -> crate::Result<()> {
                 options.output_dir,
                 &options.output_file_path,
                 options.question_policy,
-                options.is_output_dir_explicit,
+                options.is_output_dir_provided,
             )? {
                 files
             } else {
@@ -218,7 +218,7 @@ pub fn decompress_file(options: DecompressOptions) -> crate::Result<()> {
                 options.output_dir,
                 &options.output_file_path,
                 options.question_policy,
-                options.is_output_dir_explicit,
+                options.is_output_dir_provided,
             )? {
                 files
             } else {
@@ -260,7 +260,7 @@ pub fn decompress_file(options: DecompressOptions) -> crate::Result<()> {
                 options.output_dir,
                 &options.output_file_path,
                 options.question_policy,
-                options.is_output_dir_explicit,
+                options.is_output_dir_provided,
             )? {
                 files
             } else {
@@ -295,9 +295,9 @@ fn execute_decompression(
     output_dir: &Path,
     output_file_path: &Path,
     question_policy: QuestionPolicy,
-    is_output_dir_explicit: bool,
+    is_output_dir_provided: bool,
 ) -> crate::Result<ControlFlow<(), usize>> {
-    if is_output_dir_explicit {
+    if is_output_dir_provided {
         unpack(unpack_fn, output_dir, question_policy)
     } else {
         smart_unpack(unpack_fn, output_dir, output_file_path, question_policy)
@@ -313,7 +313,7 @@ fn unpack(
     output_dir: &Path,
     question_policy: QuestionPolicy,
 ) -> crate::Result<ControlFlow<(), usize>> {
-    let is_valid_output_dir = !output_dir.exists() || (output_dir.is_dir() && output_dir.read_dir()?.count() == 0);
+    let is_valid_output_dir = !output_dir.exists() || (output_dir.is_dir() && output_dir.read_dir()?.next().is_none());
 
     let output_dir_cleaned = if is_valid_output_dir {
         output_dir.to_owned()

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -176,6 +176,7 @@ pub fn run(
 
             // The directory that will contain the output files
             // We default to the current directory if the user didn't specify an output directory with --dir
+            let is_output_dir_explicit = output_dir.is_some();
             let output_dir = if let Some(dir) = output_dir {
                 utils::create_dir_if_non_existent(&dir)?;
                 dir
@@ -199,6 +200,7 @@ pub fn run(
                         formats,
                         output_dir: &output_dir,
                         output_file_path,
+                        is_output_dir_explicit,
                         question_policy,
                         quiet: args.quiet,
                         password: args.password.as_deref().map(|str| {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -176,7 +176,7 @@ pub fn run(
 
             // The directory that will contain the output files
             // We default to the current directory if the user didn't specify an output directory with --dir
-            let is_output_dir_explicit = output_dir.is_some();
+            let is_output_dir_provided = output_dir.is_some();
             let output_dir = if let Some(dir) = output_dir {
                 utils::create_dir_if_non_existent(&dir)?;
                 dir
@@ -200,7 +200,7 @@ pub fn run(
                         formats,
                         output_dir: &output_dir,
                         output_file_path,
-                        is_output_dir_explicit,
+                        is_output_dir_provided,
                         question_policy,
                         quiet: args.quiet,
                         password: args.password.as_deref().map(|str| {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,11 +1,7 @@
 #[macro_use]
 mod utils;
 
-use std::{
-    io::Write,
-    iter::once,
-    path::{Path, PathBuf},
-};
+use std::{iter::once, path::PathBuf};
 
 use fs_err as fs;
 use parse_display::Display;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 mod utils;
 
-use std::{iter::once, path::PathBuf};
+use std::{io::Write, iter::once, path::PathBuf};
 
 use fs_err as fs;
 use parse_display::Display;
@@ -363,7 +363,6 @@ fn multiple_files_with_conflict_and_choice_to_rename_with_already_a_renamed(
     assert_same_directory(src_files_path, dest_files_path_renamed.join("src_files"), false);
 }
 
-#[cfg(feature = "allow_piped_choice")]
 #[proptest(cases = 25)]
 fn multiple_files_with_disabled_smart_unpack_by_dir(
     ext: DirectoryExtension,
@@ -380,7 +379,7 @@ fn multiple_files_with_disabled_smart_unpack_by_dir(
         .map(|f| src_files_path.join(f))
         .map(|path| {
             let mut file = fs::File::create(&path).unwrap();
-            file.write("Some content".as_bytes()).unwrap();
+            file.write_all("Some content".as_bytes()).unwrap();
             path
         })
         .collect::<Vec<_>>();


### PR DESCRIPTION
closes #322 

## Before, with Smart Unpack when `--dir` is provided:
![image](https://github.com/user-attachments/assets/4decc380-17ac-457e-a03c-ca37fdc6d5d4)


## Now:
![image](https://github.com/user-attachments/assets/336786eb-93d7-40ef-b722-be5374d1194a)


## When there are some conflict:
![image](https://github.com/user-attachments/assets/9546f305-8a09-4dde-84bd-46e9ef0a0ab7)


**NOTE**: When smart unpack is disabled the `.tmp-ouch-xxx` folder is no longer used inside `--dir` folder to hold unpacked files before renaming them. Instead, files are unpacked directly into the `--dir` folder.
