### PR TITLE
Always run CI checks with the default features

### DIFF
--- a/.github/workflows/build-artifacts-and-run-tests.yml
+++ b/.github/workflows/build-artifacts-and-run-tests.yml
@@ -37,9 +37,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        feature-unrar: ${{ inputs.matrix_all_combinations && fromJSON('[true, false]') || fromJSON('[false]')}}
-        feature-use-zlib: ${{ inputs.matrix_all_combinations && fromJSON('[true, false]') || fromJSON('[false]')}}
-        feature-use-zstd-thin: ${{ inputs.matrix_all_combinations && fromJSON('[true, false]') || fromJSON('[false]')}}
+        feature-unrar: ${{ inputs.matrix_all_combinations && fromJSON('[true, false]') || fromJSON('[true]')}}
+        feature-use-zlib: ${{ inputs.matrix_all_combinations && fromJSON('[true, false]') || fromJSON('[true]')}}
+        feature-use-zstd-thin: ${{ inputs.matrix_all_combinations && fromJSON('[true, false]') || fromJSON('[true]')}}
         target:
           # native
           - x86_64-unknown-linux-gnu
@@ -75,12 +75,12 @@ jobs:
             use-cross: true
           - target: armv7-unknown-linux-musleabihf
             use-cross: true
-          # features (unless `matrix_all_combinations` is true, we only run these on linux-gnu)
-          - feature-unrar: true
+          # features (unless `matrix_all_combinations` is true, we'll only run with these disabled on linux-gnu)
+          - feature-unrar: false
             target: x86_64-unknown-linux-gnu
-          - feature-use-zlib: true
+          - feature-use-zlib: false
             target: x86_64-unknown-linux-gnu
-          - feature-use-zstd-thin: true
+          - feature-use-zstd-thin: false
             target: x86_64-unknown-linux-gnu
 
     steps:

--- a/.github/workflows/build-artifacts-and-run-tests.yml
+++ b/.github/workflows/build-artifacts-and-run-tests.yml
@@ -102,9 +102,9 @@ jobs:
         shell: bash
         run: |
           FEATURES=(allow_piped_choice)
+          if [[ "${{ matrix.feature-unrar }}" == true ]]; then FEATURES+=(unrar); fi
           if [[ "${{ matrix.feature-use-zlib }}" == true ]]; then FEATURES+=(use_zlib); fi
           if [[ "${{ matrix.feature-use-zstd-thin }}" == true ]]; then FEATURES+=(use_zstd_thin); fi
-          if [[ "${{ matrix.feature-unrar }}" == true ]]; then FEATURES+=(unrar); fi
           # Output plus-separated list for artifact names
           IFS='+'
           echo "FEATURES_PLUS=${FEATURES[*]}" >> $GITHUB_OUTPUT
@@ -127,7 +127,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          key: "${{ matrix.target }}-${{ matrix.feature-unrar }}-${{ matrix.feature-use-zstd-thin }}-${{ matrix.feature-unrar }}"
+          key: "${{ matrix.target }}-${{ matrix.feature-unrar }}-${{ matrix.feature-use-zlib }}-${{ matrix.feature-use-zstd-thin }}"
 
       - name: Test on stable
         # there's no way to run tests for ARM64 Windows for now
@@ -136,7 +136,7 @@ jobs:
           ${{ env.CARGO }} +stable test --profile fast --target ${{ matrix.target }} $EXTRA_CARGO_FLAGS
 
       - name: Build release artifacts (binary and completions)
-        if: ${{ inputs.upload_artifacts }}
+        if: ${{ inputs.artifact_upload_mode != 'none' }}
         run: |
           ${{ env.CARGO }} +stable build --release --target ${{ matrix.target }} $EXTRA_CARGO_FLAGS
         env:

--- a/.github/workflows/draft-release-automatic-trigger.yml
+++ b/.github/workflows/draft-release-automatic-trigger.yml
@@ -21,11 +21,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download artifacts
-        uses: dawidd6/action-download-artifact@v6
+        uses: actions/download-artifact@v4
         with:
           path: downloaded_artifacts
-          workflow: ./.github/workflows/build-artifacts-and-run-tests.yml
-          name: ouch-*
+          pattern: ouch-*
 
       - name: Package release assets
         run: scripts/package-release-assets.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,14 @@ Categories Used:
 
 **Bullet points in chronological order by PR**
 
-## [Unreleased](https://github.com/ouch-org/ouch/compare/0.5.1...HEAD)
+## [Unreleased](https://github.com/ouch-org/ouch/compare/0.6.0...HEAD)
+
+### New Features
+### Improvements
+### Bug Fixes
+### Tweaks
+
+## [0.6.0](https://github.com/ouch-org/ouch/compare/0.5.1...0.6.0)
 
 ### New Features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,7 +1066,7 @@ checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "ouch"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "assert_cmd",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ouch"
-version = "0.5.1"
+version = "0.6.0"
 authors = [
     "João Marcos <marcospb19@hotmail.com>",
     "Vinícius Rodrigues Miguel <vrmiguel99@gmail.com>",


### PR DESCRIPTION
when matrix_all_combinations is false, previously we would run all CI with the features disabled and then have 1 run for each with it enabled

now, they are always enabled, and we add 1 run that disable 1 of them

when matrix_all_combinations is true this doesn't change the fact that we'll test all combinations

