### PR TITLE
Fix `.zip` crash when file mode isn't present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Categories Used:
 ### New Features
 ### Improvements
 ### Bug Fixes
+
+- Fix .zip crash when file mode isn't present [\#804](https://github.com/ouch-org/ouch/pull/804) ([marcospb19](https://github.com/marcospb19))
+
 ### Tweaks
 
 ## [0.6.0](https://github.com/ouch-org/ouch/compare/0.5.1...0.6.0)

--- a/src/archive/zip.rs
+++ b/src/archive/zip.rs
@@ -85,10 +85,8 @@ where
                     ));
                 }
 
-                let mode = file.unix_mode().ok_or_else(|| {
-                    std::io::Error::new(std::io::ErrorKind::InvalidData, "Cannot extract file's mode")
-                })?;
-                let is_symlink = (mode & 0o170000) == 0o120000;
+                let mode = file.unix_mode();
+                let is_symlink = mode.is_some_and(|mode| mode & 0o170000 == 0o120000);
 
                 if is_symlink {
                     let mut target = String::new();


### PR DESCRIPTION
<!--
If your code changes text output, you might need to update snapshots
of UI tests, read more about `insta` at CONTRIBUTING.md.

Remember to edit `CHANGELOG.md` after opening the PR.
-->
