### PR TITLE
feat: Add comic book aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Categories Used:
 
 - Merge folders in decompression [\#798](https://github.com/ouch-org/ouch/pull/798) ([tommady](https://github.com/tommady))
 - Add `--no-smart-unpack` flag to decompression command to disable smart unpack [\#809](https://github.com/ouch-org/ouch/pull/809) ([talis-fb](https://github.com/talis-fb))
+- Add aliases for comic book archives []() ([md9753](https://github.com/md9753))
 
 ### Improvements
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,11 @@ Output:
 If you wish to exclude non-free code from your build, you can disable RAR support
 by building without the `unrar` feature.
 
-`tar` aliases are also supported: `tgz`, `tbz`, `tbz2`, `tlz4`, `txz`, `tlzma`, `tsz`, `tzst`.
+Aliases for these formats are also supported:
+- `tar`: `tgz`, `tbz`, `tbz2`, `tlz4`, `txz`, `tlzma`, `tsz`, `tzst`, `cbt`  
+- `zip`: `cbz`
+- `7z`: `cb7`
+- `rar`: `cbr`  
 
 Formats can be chained:
 

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -27,14 +27,14 @@ pub const SUPPORTED_EXTENSIONS: &[&str] = &[
     "br",
 ];
 
-pub const SUPPORTED_ALIASES: &[&str] = &["tgz", "tbz", "tlz4", "txz", "tzlma", "tsz", "tzst"];
+pub const SUPPORTED_ALIASES: &[&str] = &["tgz", "tbz", "tlz4", "txz", "tzlma", "tsz", "tzst", "cbt", "cbz", "cb7", "cbr"];
 
 #[cfg(not(feature = "unrar"))]
 pub const PRETTY_SUPPORTED_EXTENSIONS: &str = "tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, 7z";
 #[cfg(feature = "unrar")]
 pub const PRETTY_SUPPORTED_EXTENSIONS: &str = "tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, rar, 7z";
 
-pub const PRETTY_SUPPORTED_ALIASES: &str = "tgz, tbz, tlz4, txz, tzlma, tsz, tzst";
+pub const PRETTY_SUPPORTED_ALIASES: &str = "tgz, tbz, tlz4, txz, tzlma, tsz, tzst, cbt, cbz, cb7, cbr";
 
 /// A wrapper around `CompressionFormat` that allows combinations like `tgz`
 #[derive(Debug, Clone)]
@@ -89,16 +89,16 @@ pub enum CompressionFormat {
     Lzma,
     /// .sz
     Snappy,
-    /// tar, tgz, tbz, tbz2, tbz3, txz, tlz4, tlzma, tsz, tzst
+    /// tar, tgz, tbz, tbz2, tbz3, txz, tlz4, tlzma, tsz, tzst, cbt
     Tar,
     /// .zst
     Zstd,
-    /// .zip
+    /// .zip, .cbz
     Zip,
     // even if built without RAR support, we still want to recognise the format
-    /// .rar
+    /// .rar, .cbr
     Rar,
-    /// .7z
+    /// .7z, .cb7
     SevenZip,
     /// .br
     Brotli,
@@ -125,7 +125,7 @@ impl CompressionFormat {
 fn to_extension(ext: &[u8]) -> Option<Extension> {
     Some(Extension::new(
         match ext {
-            b"tar" => &[Tar],
+            b"tar" | b"cbt" => &[Tar],
             b"tgz" => &[Tar, Gzip],
             b"tbz" | b"tbz2" => &[Tar, Bzip],
             b"tbz3" => &[Tar, Bzip3],
@@ -133,7 +133,7 @@ fn to_extension(ext: &[u8]) -> Option<Extension> {
             b"txz" | b"tlzma" => &[Tar, Lzma],
             b"tsz" => &[Tar, Snappy],
             b"tzst" => &[Tar, Zstd],
-            b"zip" => &[Zip],
+            b"zip" | b"cbz" => &[Zip],
             b"bz" | b"bz2" => &[Bzip],
             b"bz3" => &[Bzip3],
             b"gz" => &[Gzip],
@@ -141,8 +141,8 @@ fn to_extension(ext: &[u8]) -> Option<Extension> {
             b"xz" | b"lzma" => &[Lzma],
             b"sz" => &[Snappy],
             b"zst" => &[Zstd],
-            b"rar" => &[Rar],
-            b"7z" => &[SevenZip],
+            b"rar" | b"cbr" => &[Rar],
+            b"7z" | b"cb7" => &[SevenZip],
             b"br" => &[Brotli],
             _ => return None,
         },

--- a/tests/mime.rs
+++ b/tests/mime.rs
@@ -17,13 +17,16 @@ fn sanity_check_through_mime() {
     write_random_content(test_file, &mut SmallRng::from_entropy());
 
     let formats = [
-        "7z", "tar", "zip", "tar.gz", "tgz", "tbz", "tbz2", "txz", "tlzma", "tzst", "tar.bz", "tar.bz2", "tar.lzma",
-        "tar.xz", "tar.zst",
+        "7z", "cb7", "tar", "cbt", "zip", "cbz", "tar.gz", "tgz", "tbz", "tbz2", "txz", "tlzma", "tzst",
+        "tar.bz", "tar.bz2", "tar.lzma", "tar.xz", "tar.zst",
     ];
 
     let expected_mimes = [
         "application/x-7z-compressed",
+        "application/x-7z-compressed",
         "application/x-tar",
+        "application/x-tar",
+        "application/zip",
         "application/zip",
         "application/gzip",
         "application/gzip",

--- a/tests/snapshots/ui__ui_test_err_decompress_missing_extension_with_rar-1.snap
+++ b/tests/snapshots/ui__ui_test_err_decompress_missing_extension_with_rar-1.snap
@@ -7,7 +7,7 @@ expression: "run_ouch(\"ouch decompress a\", dir)"
  - Decompression formats are detected automatically from file extension
 
 hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, rar, 7z
-hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst
+hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst, cbt, cbz, cb7, cbr
 hint: 
 hint: Alternatively, you can pass an extension to the '--format' flag:
 hint:   ouch decompress <TMP_DIR>/a --format tar.gz

--- a/tests/snapshots/ui__ui_test_err_decompress_missing_extension_with_rar-2.snap
+++ b/tests/snapshots/ui__ui_test_err_decompress_missing_extension_with_rar-2.snap
@@ -8,4 +8,4 @@ expression: "run_ouch(\"ouch decompress a b.unknown\", dir)"
  - Decompression formats are detected automatically from file extension
 
 hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, rar, 7z
-hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst
+hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst, cbt, cbz, cb7, cbr

--- a/tests/snapshots/ui__ui_test_err_decompress_missing_extension_with_rar-3.snap
+++ b/tests/snapshots/ui__ui_test_err_decompress_missing_extension_with_rar-3.snap
@@ -7,7 +7,7 @@ expression: "run_ouch(\"ouch decompress b.unknown\", dir)"
  - Decompression formats are detected automatically from file extension
 
 hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, rar, 7z
-hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst
+hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst, cbt, cbz, cb7, cbr
 hint: 
 hint: Alternatively, you can pass an extension to the '--format' flag:
 hint:   ouch decompress <TMP_DIR>/b.unknown --format tar.gz

--- a/tests/snapshots/ui__ui_test_err_format_flag_with_rar-1.snap
+++ b/tests/snapshots/ui__ui_test_err_format_flag_with_rar-1.snap
@@ -6,7 +6,7 @@ expression: "run_ouch(\"ouch compress input output --format tar.gz.unknown\", di
  - Unsupported extension 'unknown'
 
 hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, rar, 7z
-hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst
+hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst, cbt, cbz, cb7, cbr
 hint: 
 hint: Examples:
 hint:   --format tar

--- a/tests/snapshots/ui__ui_test_err_format_flag_with_rar-2.snap
+++ b/tests/snapshots/ui__ui_test_err_format_flag_with_rar-2.snap
@@ -6,7 +6,7 @@ expression: "run_ouch(\"ouch compress input output --format targz\", dir)"
  - Unsupported extension 'targz'
 
 hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, rar, 7z
-hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst
+hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst, cbt, cbz, cb7, cbr
 hint: 
 hint: Examples:
 hint:   --format tar

--- a/tests/snapshots/ui__ui_test_err_format_flag_with_rar-3.snap
+++ b/tests/snapshots/ui__ui_test_err_format_flag_with_rar-3.snap
@@ -6,7 +6,7 @@ expression: "run_ouch(\"ouch compress input output --format .tar.$#!@.rest\", di
  - Unsupported extension '$#!@'
 
 hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, rar, 7z
-hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst
+hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst, cbt, cbz, cb7, cbr
 hint: 
 hint: Examples:
 hint:   --format tar


### PR DESCRIPTION
Addresses https://github.com/ouch-org/ouch/discussions/831

[Several archive formats have commonly-used aliases for storing comic books.](https://en.wikipedia.org/wiki/Comic_book_archive) This PR adds those aliases for the formats Ouch already supports:

    tar: .cbt
    zip: .cbz
    7z: .cb7
    rar: .cbr

![Screenshot_20250628_112935](https://github.com/user-attachments/assets/b64e28da-73ab-482b-9e1d-1c317398ad3a)

I'm very new to Rust, so a close eye when looking this over would be appreciated.