### PR TITLE
Add basic support for squashfs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "backhand"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c45726a83c67f85d931ef28d331cbc4108b179e06359ed84944313dfc2bb9ce1"
+dependencies = [
+ "deku",
+ "flate2",
+ "lz4_flex",
+ "rayon",
+ "solana-nohash-hasher",
+ "thiserror 2.0.12",
+ "tracing",
+ "xxhash-rust",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +198,18 @@ name = "bitflags"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "block-buffer"
@@ -284,7 +314,7 @@ dependencies = [
  "byteorder",
  "bytesize",
  "libbzip3-sys",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -521,6 +551,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "deku"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476a022dcfbb013d1365734a42e05b6aca967ebe0d3bb38170086abd9ea3324"
+dependencies = [
+ "bitvec",
+ "deku_derive",
+ "no_std_io2",
+ "rustversion",
+]
+
+[[package]]
+name = "deku_derive"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb216d425bdf810c165a8ae1649523033e88b5f795480ccec63926295541b084"
+dependencies = [
+ "darling",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,6 +661,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,6 +712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "libz-sys",
  "miniz_oxide",
 ]
@@ -647,6 +744,12 @@ checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-core"
@@ -728,8 +831,14 @@ dependencies = [
  "libz-sys",
  "num_cpus",
  "snap",
- "thiserror",
+ "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heck"
@@ -771,6 +880,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "ignore"
 version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,6 +899,16 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -938,6 +1063,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-rs-sys"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "902bc563b5d65ad9bba616b490842ef0651066a1a1dc3ce1087113ffcb873c8d"
+dependencies = [
+ "zlib-rs",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,6 +1171,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "no_std_io2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c2b9acd47481ab557a89a5665891be79e43cce8a29ad77aa9419d7be5a7c06a"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,6 +1238,7 @@ version = "0.6.1"
 dependencies = [
  "assert_cmd",
  "atty",
+ "backhand",
  "brotli",
  "bstr",
  "bytesize",
@@ -1214,6 +1358,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,6 +1437,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,6 +1488,12 @@ checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1596,6 +1761,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
+name = "solana-nohash-hasher"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b8a731ed60e89177c8a7ab05fe0f1511cedd3e70e773f288f9de33a9cfdc21e"
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1668,6 +1839,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tar"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1716,7 +1893,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -1724,6 +1910,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1758,6 +1955,54 @@ checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -2059,12 +2304,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
  "bitflags 2.8.0",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]
@@ -2077,6 +2340,12 @@ dependencies = [
  "linux-raw-sys",
  "rustix",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "xz2"
@@ -2151,6 +2420,12 @@ dependencies = [
  "sha1",
  "time",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b20717f0917c908dc63de2e44e97f1e6b126ca58d0e391cee86d504eb8fbd05"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ description = "A command-line utility for easily compressing and decompressing f
 
 [dependencies]
 atty = "0.2.14"
+# FIXME: `xz` features cannot be enabled because it uses `lzma-sys` which cannot co-exist with our dependency `xz2`.
+backhand = { version = "0.23.0", default-features = false, features = ["parallel", "gzip", "lz4", "zstd"] }
 brotli = "7.0.0"
 bstr = { version = "1.10.0", default-features = false, features = ["std"] }
 bytesize = "1.3.0"

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ Output:
 
 # Supported formats
 
-| Format    | `.tar` | `.zip` | `7z` | `.gz` | `.xz`, `.lzma` | `.bz`, `.bz2` | `.bz3` | `.lz4` | `.sz` (Snappy) | `.zst` | `.rar` | `.br` |
-|:---------:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| Supported | ✓ | ✓¹ | ✓¹ | ✓² | ✓ | ✓ | ✓ | ✓ | ✓² | ✓² | ✓³ | ✓ |
+| Format    | `.tar` | `.zip` | `7z` | `.gz` | `.xz`, `.lzma` | `.bz`, `.bz2` | `.bz3` | `.lz4` | `.sz` (Snappy) | `.zst` | `.rar` | `.br` | `.sqfs`, `.squashfs` |
+|:---------:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| Supported | ✓ | ✓¹ | ✓¹ | ✓² | ✓ | ✓ | ✓ | ✓ | ✓² | ✓² | ✓³ | ✓ | ✓¹ |
 
 ✓: Supports compression and decompression.
 

--- a/src/archive/mod.rs
+++ b/src/archive/mod.rs
@@ -7,5 +7,6 @@ pub mod rar;
 #[cfg(not(feature = "unrar"))]
 pub mod rar_stub;
 pub mod sevenz;
+pub mod squashfs;
 pub mod tar;
 pub mod zip;

--- a/src/archive/squashfs.rs
+++ b/src/archive/squashfs.rs
@@ -1,17 +1,23 @@
 use std::{
-    fs,
-    io::{self, BufWriter, Write},
-    path::Path,
+    env, fs,
+    io::{self, BufWriter, Seek, Write},
+    path::{Path, PathBuf},
+    time::SystemTime,
 };
 
-use backhand::{FilesystemReader, InnerNode, SquashfsFileReader};
-use filetime_creation::{set_file_handle_times, set_file_mtime, FileTime};
+use backhand::{
+    compression::Compressor, FilesystemCompressor, FilesystemReader, FilesystemWriter, InnerNode, NodeHeader,
+    SquashfsFileReader,
+};
+use filetime_creation::{set_file_handle_times, FileTime};
+use same_file::Handle;
 
 use crate::{
+    error::FinalError,
     list::FileInArchive,
     utils::{
         logger::{info, warning},
-        Bytes,
+        Bytes, FileVisibilityPolicy,
     },
 };
 
@@ -130,4 +136,206 @@ pub fn unpack_archive(archive: FilesystemReader<'_>, output_folder: &Path, quiet
     }
 
     Ok(unpacked_files)
+}
+
+pub fn build_archive_from_paths<W>(
+    input_filenames: &[PathBuf],
+    output_path: &Path,
+    mut writer: W,
+    file_visibility_policy: FileVisibilityPolicy,
+    quiet: bool,
+    follow_symlinks: bool,
+) -> crate::Result<W>
+where
+    W: Write + Seek,
+{
+    let root_dir = match input_filenames {
+        [path] if path.is_dir() => path,
+        _ => {
+            let error = FinalError::with_title("Cannot build squashfs")
+                .detail("Squashfs requires a single directory input for root directory")
+                .detail(if input_filenames.len() != 1 {
+                    "Multiple paths are provided".into()
+                } else {
+                    format!("Not a directory: {:?}", input_filenames[0])
+                });
+            return Err(error.into());
+        }
+    };
+
+    let output_handle = Handle::from_path(output_path);
+
+    let mut fs_writer = FilesystemWriter::default();
+    // Set the default compression to Gzip with default level, matching mksquashfs's default.
+    // The default choice of `backhand` is Xz which is not enabled by us.
+    // TODO: We do not support customization argument for archive formats.
+    fs_writer.set_compressor(FilesystemCompressor::new(Compressor::Gzip, None).expect("gzip is supported"));
+
+    // cd *into* the source directory, using it as the archive root.
+    let previous_cwd = env::current_dir()?;
+    env::set_current_dir(root_dir)?;
+
+    for entry in file_visibility_policy.build_walker(".") {
+        let entry = entry?;
+        let path = entry.path();
+
+        if let Ok(handle) = &output_handle {
+            if matches!(Handle::from_path(path), Ok(x) if &x == handle) {
+                warning(format!(
+                    "Cannot compress `{}` into itself, skipping",
+                    output_path.display()
+                ));
+            }
+        }
+
+        if !quiet {
+            // `fs_writer.push_*` only maintains metadata. We do not want to give
+            // users a false information that we are compressing during the
+            // traversal. So this is not "compressing".
+            // File reading, compression and writing are done in
+            // `fs_writer.write` below, after the hierarchy tree gets finalized.
+            info(format!("Found {path:?}"));
+        }
+
+        let metadata = entry.metadata()?;
+        let file_type = metadata.file_type();
+
+        let mut header = NodeHeader::default();
+        header.mtime = match metadata.modified() {
+            // Not available.
+            Err(_) => 0,
+            Ok(mtime) => {
+                let mtime = mtime
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .ok()
+                    .and_then(|dur| u32::try_from(dur.as_secs()).ok());
+                if mtime.is_none() {
+                    warning(format!(
+                        "Modification time of {path:?} exceeds the representable range (1970-01-01 ~ 2106-02-07) \
+                        of squashfs. Recorded as 1970-01-01."
+                    ));
+                }
+                mtime.unwrap_or(0)
+            }
+        };
+
+        #[cfg(not(unix))]
+        {
+            header.permissions = 0o777;
+        }
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+            // Only permission bits, not file type bits.
+            header.permissions = metadata.permissions().mode() as u16 & !(libc::S_IFMT as u16);
+            header.uid = metadata.uid();
+            header.gid = metadata.gid();
+        }
+
+        // Root directory is special cased.
+        if path == Path::new(".") {
+            fs_writer.set_root_mode(header.permissions);
+            fs_writer.set_root_uid(header.uid);
+            fs_writer.set_root_gid(header.gid);
+            continue;
+        }
+
+        if file_type.is_dir() {
+            fs_writer.push_dir(path, header)?;
+        } else if !follow_symlinks && file_type.is_symlink() {
+            let target = fs::read_link(path)?;
+            fs_writer.push_symlink(target, path, header)?;
+        } else if maybe_push_unix_special_inode(&mut fs_writer, path, &metadata, header)? {
+            // Already handled.
+        } else {
+            // Fallback case: read as a regular file.
+            // See comments of `LazyFile` for why not `File::open` here.
+            let reader = LazyFile::Path(path.to_path_buf());
+            fs_writer.push_file(reader, path, header)?;
+        }
+    }
+
+    if !quiet {
+        info(format!("Compressing data"));
+    }
+
+    // Finalize the superblock and write data. This should be done before
+    // resetting current directory, because `LazyFile`s store relative paths.
+    fs_writer.write(&mut writer)?;
+
+    env::set_current_dir(previous_cwd)?;
+
+    Ok(writer)
+}
+
+#[cfg(not(unix))]
+fn maybe_push_unix_special_inode(
+    _writer: &mut FilesystemWriter,
+    _path: &Path,
+    _metadata: &fs::Metadata,
+    _header: NodeHeader,
+) -> io::Result<bool> {
+    Ok(false)
+}
+
+#[cfg(unix)]
+fn maybe_push_unix_special_inode(
+    writer: &mut FilesystemWriter,
+    path: &Path,
+    metadata: &fs::Metadata,
+    header: NodeHeader,
+) -> io::Result<bool> {
+    use std::os::unix::fs::{FileTypeExt, MetadataExt};
+
+    let file_type = metadata.file_type();
+    if file_type.is_fifo() {
+        writer.push_fifo(path, header)?;
+    } else if file_type.is_socket() {
+        writer.push_socket(path, header)?;
+    } else if file_type.is_block_device() {
+        let dev = metadata.rdev() as u32;
+        writer.push_block_device(dev, path, header)?;
+    } else if file_type.is_char_device() {
+        let dev = metadata.rdev() as u32;
+        writer.push_char_device(dev, path, header)?;
+    } else {
+        return Ok(false);
+    }
+    Ok(true)
+}
+
+/// Delay file opening until the first read and close it as soon as the EOF is encountered.
+///
+/// Due to design of `backhand`, we need to store all `impl Read` into the
+/// builder during traversal and write out the squashfs later. But we cannot
+/// open and store all file handles during traversal or it will exhaust file
+/// descriptors on *NIX if there are thousands of files (a pretty low limit!).
+///
+/// Upstream discussion: https://github.com/wcampbell0x2a/backhand/discussions/614
+enum LazyFile {
+    Path(PathBuf),
+    Opened(fs::File),
+    Closed,
+}
+
+impl io::Read for LazyFile {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            LazyFile::Path(path) => {
+                let file = fs::File::open(path)?;
+                *self = Self::Opened(file);
+                self.read(buf)
+            }
+            LazyFile::Opened(file) => {
+                let cnt = file.read(buf)?;
+                if buf.len() != 0 && cnt == 0 {
+                    *self = Self::Closed;
+                }
+                Ok(cnt)
+            }
+            LazyFile::Closed => Ok(0),
+        }
+    }
 }

--- a/src/archive/squashfs.rs
+++ b/src/archive/squashfs.rs
@@ -1,8 +1,19 @@
-use std::path::Path;
+use std::{
+    fs,
+    io::{self, BufWriter, Write},
+    path::Path,
+};
 
-use backhand::{FilesystemReader, InnerNode};
+use backhand::{FilesystemReader, InnerNode, SquashfsFileReader};
+use filetime_creation::{set_file_handle_times, set_file_mtime, FileTime};
 
-use crate::list::FileInArchive;
+use crate::{
+    list::FileInArchive,
+    utils::{
+        logger::{info, warning},
+        Bytes,
+    },
+};
 
 pub fn list_archive<'a>(archive: FilesystemReader<'a>) -> impl Iterator<Item = crate::Result<FileInArchive>> + 'a {
     archive.root.nodes.into_iter().filter_map(move |f| {
@@ -20,4 +31,103 @@ pub fn list_archive<'a>(archive: FilesystemReader<'a>) -> impl Iterator<Item = c
                 .to_path_buf(),
         }))
     })
+}
+
+pub fn unpack_archive(archive: FilesystemReader<'_>, output_folder: &Path, quiet: bool) -> crate::Result<usize> {
+    let mut unpacked_files = 0usize;
+
+    for f in archive.files() {
+        // `output_folder` should already be created.
+        if f.fullpath == Path::new("/") {
+            continue;
+        }
+
+        let relative_path = f.fullpath.strip_prefix("/").expect("paths must be absolute");
+        let file_path = output_folder.join(relative_path);
+
+        let mtime = FileTime::from_unix_time(f.header.mtime.into(), 0);
+
+        let warn_ignored = |inode_type: &str| {
+            warning(format!("ignored {inode_type} in archive {relative_path:?}"));
+        };
+
+        match &f.inner {
+            InnerNode::Dir(_) => {
+                if !quiet {
+                    info(format!("extracting directory {file_path:?}"));
+                }
+                fs::create_dir(&file_path)?;
+                // Directory mtime is not recovered. It will be overwritten by
+                // the creation of inner files. We would need a second pass to do so.
+            }
+            InnerNode::File(file) => {
+                if !quiet {
+                    let file_size = Bytes::new(match file {
+                        SquashfsFileReader::Basic(f) => f.file_size.into(),
+                        SquashfsFileReader::Extended(f) => f.file_size,
+                    });
+                    info(format!("extracting file ({file_size}) {file_path:?}"));
+                }
+
+                let mut reader = archive.file(file).reader();
+                let output_file = fs::File::create(&file_path)?;
+                let mut output_file = BufWriter::new(output_file);
+                io::copy(&mut reader, &mut output_file)?;
+                output_file.flush()?;
+                set_file_handle_times(output_file.get_ref(), None, Some(mtime), None)?;
+            }
+            InnerNode::Symlink(symlink) => {
+                if !quiet {
+                    info(format!("extracting symlink {file_path:?}"));
+                }
+
+                let target = &symlink.link;
+                #[cfg(unix)]
+                {
+                    std::os::unix::fs::symlink(&target, &file_path)?;
+                    filetime_creation::set_symlink_file_times(&file_path, mtime, mtime, mtime)?;
+                    // Note: Symlink permissions are ignored on *NIX anyway. No need to set them.
+                }
+
+                #[cfg(windows)]
+                std::os::windows::fs::symlink_file(&target, &file_path)?;
+
+                // Symlink mtime is specially handled above. Skip the normal handler.
+                unpacked_files += 1;
+                continue;
+            }
+
+            // TODO: Named pipes and sockets *CAN* be created by unprivileged users.
+            // Should we extract them by default?
+            InnerNode::NamedPipe => {
+                warn_ignored("named pipe");
+                continue;
+            }
+            InnerNode::Socket => {
+                warn_ignored("socket");
+                continue;
+            }
+
+            // Not possible without root permission.
+            InnerNode::CharacterDevice(_) => {
+                warn_ignored("character device");
+                continue;
+            }
+            InnerNode::BlockDevice(_) => {
+                warn_ignored("block device");
+                continue;
+            }
+        }
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            fs::set_permissions(&file_path, fs::Permissions::from_mode(f.header.permissions.into()))?;
+        }
+
+        unpacked_files += 1;
+    }
+
+    Ok(unpacked_files)
 }

--- a/src/archive/squashfs.rs
+++ b/src/archive/squashfs.rs
@@ -1,0 +1,23 @@
+use std::path::Path;
+
+use backhand::{FilesystemReader, InnerNode};
+
+use crate::list::FileInArchive;
+
+pub fn list_archive<'a>(archive: FilesystemReader<'a>) -> impl Iterator<Item = crate::Result<FileInArchive>> + 'a {
+    archive.root.nodes.into_iter().filter_map(move |f| {
+        // The reported paths are absolute, and include the root directory `/`.
+        // To be consistent with outputs of other formats, we strip the prefix `/` and ignore the root directory.
+        if f.fullpath == Path::new("/") {
+            return None;
+        }
+        Some(Ok(FileInArchive {
+            is_dir: matches!(f.inner, InnerNode::Dir(_)),
+            path: f
+                .fullpath
+                .strip_prefix("/")
+                .expect("paths must be absolute")
+                .to_path_buf(),
+        }))
+    })
+}

--- a/src/archive/squashfs.rs
+++ b/src/archive/squashfs.rs
@@ -90,7 +90,7 @@ pub fn unpack_archive(archive: FilesystemReader<'_>, output_folder: &Path, quiet
                 let target = &symlink.link;
                 #[cfg(unix)]
                 {
-                    std::os::unix::fs::symlink(&target, &file_path)?;
+                    std::os::unix::fs::symlink(target, &file_path)?;
                     filetime_creation::set_symlink_file_times(&file_path, mtime, mtime, mtime)?;
                     // Note: Symlink permissions are ignored on *NIX anyway. No need to set them.
                 }
@@ -138,6 +138,8 @@ pub fn unpack_archive(archive: FilesystemReader<'_>, output_folder: &Path, quiet
     Ok(unpacked_files)
 }
 
+// Re-assignments work bettwe with `cfg` blocks.
+#[allow(clippy::field_reassign_with_default)]
 pub fn build_archive_from_paths<W>(
     input_filenames: &[PathBuf],
     output_path: &Path,
@@ -258,7 +260,7 @@ where
     }
 
     if !quiet {
-        info(format!("Compressing data"));
+        info("Compressing data".to_string());
     }
 
     // Finalize the superblock and write data. This should be done before
@@ -330,7 +332,7 @@ impl io::Read for LazyFile {
             }
             LazyFile::Opened(file) => {
                 let cnt = file.read(buf)?;
-                if buf.len() != 0 && cnt == 0 {
+                if !buf.is_empty() && cnt == 0 {
                     *self = Self::Closed;
                 }
                 Ok(cnt)

--- a/src/commands/decompress.rs
+++ b/src/commands/decompress.rs
@@ -4,6 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use backhand::BufReadSeek;
 use fs_err as fs;
 
 #[cfg(not(feature = "bzip3"))]
@@ -24,9 +25,6 @@ use crate::{
     },
     QuestionAction, QuestionPolicy, BUFFER_CAPACITY,
 };
-
-trait ReadSeek: Read + io::Seek {}
-impl<T: Read + io::Seek> ReadSeek for T {}
 
 pub struct DecompressOptions<'a> {
     pub input_file_path: &'a Path,
@@ -59,21 +57,32 @@ pub fn decompress_file(options: DecompressOptions) -> crate::Result<()> {
     //
     // Any other Zip decompression done can take up the whole RAM and freeze ouch.
     if let [Extension {
-        compression_formats: [Zip],
+        compression_formats: [archive_format @ (Zip | Squashfs)],
         ..
     }] = options.formats.as_slice()
     {
+        let is_zip = matches!(archive_format, Zip);
+
         let mut vec = vec![];
-        let reader: Box<dyn ReadSeek> = if input_is_stdin {
-            warn_user_about_loading_in_memory(".zip");
+        let reader: Box<dyn BufReadSeek> = if input_is_stdin {
+            warn_user_about_loading_in_memory(if is_zip { ".zip" } else { ".sqfs" });
             io::copy(&mut io::stdin(), &mut vec)?;
             Box::new(io::Cursor::new(vec))
         } else {
-            Box::new(fs::File::open(options.input_file_path)?)
+            let file = fs::File::open(options.input_file_path)?;
+            let file = BufReader::new(file);
+            Box::new(file)
         };
-        let zip_archive = zip::ZipArchive::new(reader)?;
         let files_unpacked = if let ControlFlow::Continue(files) = execute_decompression(
-            |output_dir| crate::archive::zip::unpack_archive(zip_archive, output_dir, options.password, options.quiet),
+            |output_dir| {
+                if is_zip {
+                    let zip_archive = zip::ZipArchive::new(reader)?;
+                    crate::archive::zip::unpack_archive(zip_archive, output_dir, options.password, options.quiet)
+                } else {
+                    let archive = backhand::FilesystemReader::from_reader(reader)?;
+                    crate::archive::squashfs::unpack_archive(archive, output_dir, options.quiet)
+                }
+            },
             options.output_dir,
             &options.output_file_path,
             options.question_policy,
@@ -174,14 +183,15 @@ pub fn decompress_file(options: DecompressOptions) -> crate::Result<()> {
                 return Ok(());
             }
         }
-        Squashfs => todo!(),
-        Zip => {
+        Zip | Squashfs => {
+            let is_zip = matches!(first_extension, Zip);
+
             if options.formats.len() > 1 {
                 // Locking necessary to guarantee that warning and question
                 // messages stay adjacent
                 let _locks = lock_and_flush_output_stdio();
 
-                warn_user_about_loading_in_memory(".zip");
+                warn_user_about_loading_in_memory(if is_zip { ".zip" } else { ".sqfs" });
                 if !user_wants_to_continue(
                     options.input_file_path,
                     options.question_policy,
@@ -193,11 +203,17 @@ pub fn decompress_file(options: DecompressOptions) -> crate::Result<()> {
 
             let mut vec = vec![];
             io::copy(&mut reader, &mut vec)?;
-            let zip_archive = zip::ZipArchive::new(io::Cursor::new(vec))?;
+            let reader = io::Cursor::new(vec);
 
             if let ControlFlow::Continue(files) = execute_decompression(
-                |output_dir| {
-                    crate::archive::zip::unpack_archive(zip_archive, output_dir, options.password, options.quiet)
+                move |output_dir| {
+                    if is_zip {
+                        let archive = zip::ZipArchive::new(reader)?;
+                        crate::archive::zip::unpack_archive(archive, output_dir, options.password, options.quiet)
+                    } else {
+                        let archive = backhand::FilesystemReader::from_reader(reader)?;
+                        crate::archive::squashfs::unpack_archive(archive, output_dir, options.quiet)
+                    }
                 },
                 options.output_dir,
                 &options.output_file_path,

--- a/src/commands/decompress.rs
+++ b/src/commands/decompress.rs
@@ -49,13 +49,13 @@ pub fn decompress_file(options: DecompressOptions) -> crate::Result<()> {
     assert!(options.output_dir.exists());
     let input_is_stdin = is_path_stdin(options.input_file_path);
 
-    // Zip archives are special, because they require io::Seek, so it requires it's logic separated
+    // Zip and squashfs archives are special, because they require io::Seek, so it requires it's logic separated
     // from decoder chaining.
     //
     // This is the only case where we can read and unpack it directly, without having to do
     // in-memory decompression/copying first.
     //
-    // Any other Zip decompression done can take up the whole RAM and freeze ouch.
+    // Any other decompression done can take up the whole RAM and freeze ouch.
     if let [Extension {
         compression_formats: [archive_format @ (Zip | Squashfs)],
         ..

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -25,7 +25,7 @@ pub fn list_archive_contents(
 ) -> crate::Result<()> {
     let reader = fs::File::open(archive_path)?;
 
-    // Zip archives are special, because they require io::Seek, so it requires it's logic separated
+    // Zip and squashfs archives are special, because they require io::Seek, so it requires it's logic separated
     // from decoder chaining.
     //
     // This is the only case where we can read and unpack it directly, without having to do

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -25,24 +25,15 @@ use crate::{
     CliArgs, QuestionPolicy,
 };
 
-/// Warn the user that (de)compressing this .zip archive might freeze their system.
-fn warn_user_about_loading_zip_in_memory() {
-    const ZIP_IN_MEMORY_LIMITATION_WARNING: &str = "\n  \
-        The format '.zip' is limited by design and cannot be (de)compressed with encoding streams.\n  \
-        When chaining '.zip' with other formats, all (de)compression needs to be done in-memory\n  \
-        Careful, you might run out of RAM if the archive is too large!";
-
-    eprintln!("{}[WARNING]{}: {ZIP_IN_MEMORY_LIMITATION_WARNING}", *ORANGE, *RESET);
-}
-
-/// Warn the user that (de)compressing this .7z archive might freeze their system.
-fn warn_user_about_loading_sevenz_in_memory() {
-    const SEVENZ_IN_MEMORY_LIMITATION_WARNING: &str = "\n  \
-        The format '.7z' is limited by design and cannot be (de)compressed with encoding streams.\n  \
-        When chaining '.7z' with other formats, all (de)compression needs to be done in-memory\n  \
-        Careful, you might run out of RAM if the archive is too large!";
-
-    eprintln!("{}[WARNING]{}: {SEVENZ_IN_MEMORY_LIMITATION_WARNING}", *ORANGE, *RESET);
+/// Warn the user that (de)compressing this format might freeze their system.
+fn warn_user_about_loading_in_memory(ext: &str) {
+    eprintln!(
+        "{}[WARNING]{}:\n  \
+        The format '{ext}' is limited by design and cannot be (de)compressed with encoding streams.\n  \
+        When chaining '{ext}' with other formats, all (de)compression needs to be done in-memory\n  \
+        Careful, you might run out of RAM if the archive is too large!",
+        *ORANGE, *RESET
+    );
 }
 
 /// This function checks what command needs to be run and performs A LOT of ahead-of-time checks

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -102,6 +102,14 @@ pub enum CompressionFormat {
     SevenZip,
     /// .br
     Brotli,
+    /// .squashfs, .sqfs
+    //
+    // Note: There is not canonical extension for squashfs, we pick the two semi-official ones:
+    // - `.squashfs`: The most popular one from a quick search on GitHub. Also used by some distros.
+    //   https://github.com/NixOS/nixpkgs/blob/6576d979e9a64d870b1f298a5c598116891a6c25/nixos/modules/installer/cd-dvd/iso-image.nix#L797
+    // - `.sqfs`: Mentioned in `man mksquashfs` by squashfs-tools, the reference implementation.
+    //   https://github.com/plougher/squashfs-tools/blob/9f9bbd79016ff04967800f4301c7a9d0024c0c91/Documentation/manpages/mksquashfs.1#L494
+    Squashfs,
 }
 
 impl CompressionFormat {
@@ -109,7 +117,7 @@ impl CompressionFormat {
     pub fn archive_format(&self) -> bool {
         // Keep this match like that without a wildcard `_` so we don't forget to update it
         match self {
-            Tar | Zip | Rar | SevenZip => true,
+            Tar | Zip | Rar | SevenZip | Squashfs => true,
             Gzip => false,
             Bzip => false,
             Bzip3 => false,
@@ -144,6 +152,7 @@ fn to_extension(ext: &[u8]) -> Option<Extension> {
             b"rar" => &[Rar],
             b"7z" => &[SevenZip],
             b"br" => &[Brotli],
+            b"sqfs" | b"squashfs" => &[Squashfs],
             _ => return None,
         },
         ext.to_str_lossy(),

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -25,16 +25,18 @@ pub const SUPPORTED_EXTENSIONS: &[&str] = &[
     "rar",
     "7z",
     "br",
+    // TODO(review): Which to use as "official" extension? squashfs or sqfs?
+    "sqfs",
 ];
 
-pub const SUPPORTED_ALIASES: &[&str] = &["tgz", "tbz", "tlz4", "txz", "tzlma", "tsz", "tzst"];
+pub const SUPPORTED_ALIASES: &[&str] = &["tgz", "tbz", "tlz4", "txz", "tzlma", "tsz", "tzst", "squashfs"];
 
 #[cfg(not(feature = "unrar"))]
-pub const PRETTY_SUPPORTED_EXTENSIONS: &str = "tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, 7z";
+pub const PRETTY_SUPPORTED_EXTENSIONS: &str = "tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, 7z, sqfs";
 #[cfg(feature = "unrar")]
-pub const PRETTY_SUPPORTED_EXTENSIONS: &str = "tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, rar, 7z";
+pub const PRETTY_SUPPORTED_EXTENSIONS: &str = "tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, rar, 7z, sqfs";
 
-pub const PRETTY_SUPPORTED_ALIASES: &str = "tgz, tbz, tlz4, txz, tzlma, tsz, tzst";
+pub const PRETTY_SUPPORTED_ALIASES: &str = "tgz, tbz, tlz4, txz, tzlma, tsz, tzst, squashfs";
 
 /// A wrapper around `CompressionFormat` that allows combinations like `tgz`
 #[derive(Debug, Clone)]

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -158,6 +158,10 @@ pub fn try_infer_extension(path: &Path) -> Option<Extension> {
     fn is_sevenz(buf: &[u8]) -> bool {
         buf.starts_with(&[0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C])
     }
+    fn is_squashfs(buf: &[u8]) -> bool {
+        // Ref: https://dr-emann.github.io/squashfs/squashfs.html#_the_superblock
+        buf.starts_with(b"hsqs")
+    }
 
     let buf = {
         let mut buf = [0; 270];
@@ -195,6 +199,8 @@ pub fn try_infer_extension(path: &Path) -> Option<Extension> {
         Some(Extension::new(&[Rar], "rar"))
     } else if is_sevenz(&buf) {
         Some(Extension::new(&[SevenZip], "7z"))
+    } else if is_squashfs(&buf) {
+        Some(Extension::new(&[Squashfs], "sqfs"))
     } else {
         None
     }

--- a/tests/snapshots/ui__ui_test_err_decompress_missing_extension_with_rar-1.snap
+++ b/tests/snapshots/ui__ui_test_err_decompress_missing_extension_with_rar-1.snap
@@ -6,8 +6,8 @@ expression: "run_ouch(\"ouch decompress a\", dir)"
  - Files with missing extensions: <TMP_DIR>/a
  - Decompression formats are detected automatically from file extension
 
-hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, rar, 7z
-hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst
+hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, rar, 7z, sqfs
+hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst, squashfs
 hint: 
 hint: Alternatively, you can pass an extension to the '--format' flag:
 hint:   ouch decompress <TMP_DIR>/a --format tar.gz

--- a/tests/snapshots/ui__ui_test_err_decompress_missing_extension_with_rar-2.snap
+++ b/tests/snapshots/ui__ui_test_err_decompress_missing_extension_with_rar-2.snap
@@ -7,5 +7,5 @@ expression: "run_ouch(\"ouch decompress a b.unknown\", dir)"
  - Files with missing extensions: <TMP_DIR>/a
  - Decompression formats are detected automatically from file extension
 
-hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, rar, 7z
-hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst
+hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, rar, 7z, sqfs
+hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst, squashfs

--- a/tests/snapshots/ui__ui_test_err_decompress_missing_extension_with_rar-3.snap
+++ b/tests/snapshots/ui__ui_test_err_decompress_missing_extension_with_rar-3.snap
@@ -6,8 +6,8 @@ expression: "run_ouch(\"ouch decompress b.unknown\", dir)"
  - Files with unsupported extensions: <TMP_DIR>/b.unknown
  - Decompression formats are detected automatically from file extension
 
-hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, rar, 7z
-hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst
+hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, rar, 7z, sqfs
+hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst, squashfs
 hint: 
 hint: Alternatively, you can pass an extension to the '--format' flag:
 hint:   ouch decompress <TMP_DIR>/b.unknown --format tar.gz

--- a/tests/snapshots/ui__ui_test_err_decompress_missing_extension_without_rar-1.snap
+++ b/tests/snapshots/ui__ui_test_err_decompress_missing_extension_without_rar-1.snap
@@ -6,8 +6,8 @@ expression: "run_ouch(\"ouch decompress a\", dir)"
  - Files with missing extensions: <TMP_DIR>/a
  - Decompression formats are detected automatically from file extension
 
-hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, 7z
-hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst
+hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, 7z, sqfs
+hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst, squashfs
 hint: 
 hint: Alternatively, you can pass an extension to the '--format' flag:
 hint:   ouch decompress <TMP_DIR>/a --format tar.gz

--- a/tests/snapshots/ui__ui_test_err_decompress_missing_extension_without_rar-2.snap
+++ b/tests/snapshots/ui__ui_test_err_decompress_missing_extension_without_rar-2.snap
@@ -7,5 +7,5 @@ expression: "run_ouch(\"ouch decompress a b.unknown\", dir)"
  - Files with missing extensions: <TMP_DIR>/a
  - Decompression formats are detected automatically from file extension
 
-hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, 7z
-hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst
+hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, 7z, sqfs
+hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst, squashfs

--- a/tests/snapshots/ui__ui_test_err_decompress_missing_extension_without_rar-3.snap
+++ b/tests/snapshots/ui__ui_test_err_decompress_missing_extension_without_rar-3.snap
@@ -6,8 +6,8 @@ expression: "run_ouch(\"ouch decompress b.unknown\", dir)"
  - Files with unsupported extensions: <TMP_DIR>/b.unknown
  - Decompression formats are detected automatically from file extension
 
-hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, 7z
-hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst
+hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, 7z, sqfs
+hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst, squashfs
 hint: 
 hint: Alternatively, you can pass an extension to the '--format' flag:
 hint:   ouch decompress <TMP_DIR>/b.unknown --format tar.gz

--- a/tests/snapshots/ui__ui_test_err_format_flag_with_rar-1.snap
+++ b/tests/snapshots/ui__ui_test_err_format_flag_with_rar-1.snap
@@ -5,8 +5,8 @@ expression: "run_ouch(\"ouch compress input output --format tar.gz.unknown\", di
 [ERROR] Failed to parse `--format tar.gz.unknown`
  - Unsupported extension 'unknown'
 
-hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, rar, 7z
-hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst
+hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, rar, 7z, sqfs
+hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst, squashfs
 hint: 
 hint: Examples:
 hint:   --format tar

--- a/tests/snapshots/ui__ui_test_err_format_flag_with_rar-2.snap
+++ b/tests/snapshots/ui__ui_test_err_format_flag_with_rar-2.snap
@@ -5,8 +5,8 @@ expression: "run_ouch(\"ouch compress input output --format targz\", dir)"
 [ERROR] Failed to parse `--format targz`
  - Unsupported extension 'targz'
 
-hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, rar, 7z
-hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst
+hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, rar, 7z, sqfs
+hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst, squashfs
 hint: 
 hint: Examples:
 hint:   --format tar

--- a/tests/snapshots/ui__ui_test_err_format_flag_with_rar-3.snap
+++ b/tests/snapshots/ui__ui_test_err_format_flag_with_rar-3.snap
@@ -5,8 +5,8 @@ expression: "run_ouch(\"ouch compress input output --format .tar.$#!@.rest\", di
 [ERROR] Failed to parse `--format .tar.$#!@.rest`
  - Unsupported extension '$#!@'
 
-hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, rar, 7z
-hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst
+hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, rar, 7z, sqfs
+hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst, squashfs
 hint: 
 hint: Examples:
 hint:   --format tar

--- a/tests/snapshots/ui__ui_test_err_format_flag_without_rar-1.snap
+++ b/tests/snapshots/ui__ui_test_err_format_flag_without_rar-1.snap
@@ -5,8 +5,8 @@ expression: "run_ouch(\"ouch compress input output --format tar.gz.unknown\", di
 [ERROR] Failed to parse `--format tar.gz.unknown`
  - Unsupported extension 'unknown'
 
-hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, 7z
-hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst
+hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, 7z, sqfs
+hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst, squashfs
 hint: 
 hint: Examples:
 hint:   --format tar

--- a/tests/snapshots/ui__ui_test_err_format_flag_without_rar-2.snap
+++ b/tests/snapshots/ui__ui_test_err_format_flag_without_rar-2.snap
@@ -5,8 +5,8 @@ expression: "run_ouch(\"ouch compress input output --format targz\", dir)"
 [ERROR] Failed to parse `--format targz`
  - Unsupported extension 'targz'
 
-hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, 7z
-hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst
+hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, 7z, sqfs
+hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst, squashfs
 hint: 
 hint: Examples:
 hint:   --format tar

--- a/tests/snapshots/ui__ui_test_err_format_flag_without_rar-3.snap
+++ b/tests/snapshots/ui__ui_test_err_format_flag_without_rar-3.snap
@@ -5,8 +5,8 @@ expression: "run_ouch(\"ouch compress input output --format .tar.$#!@.rest\", di
 [ERROR] Failed to parse `--format .tar.$#!@.rest`
  - Unsupported extension '$#!@'
 
-hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, 7z
-hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst
+hint: Supported extensions are: tar, zip, bz, bz2, bz3, gz, lz4, xz, lzma, sz, zst, 7z, sqfs
+hint: Supported aliases are: tgz, tbz, tlz4, txz, tzlma, tsz, tzst, squashfs
 hint: 
 hint: Examples:
 hint:   --format tar


### PR DESCRIPTION
<!--
If your code changes text output, you might need to update snapshots
of UI tests, read more about `insta` at CONTRIBUTING.md.

Remember to edit `CHANGELOG.md` after opening the PR.
-->

Fixes #830 

The code mostly follows Zip implementations, using internal buffers for `Seek` requirement.

Unresolved questions:
1. Which extension to mention in docs? `.squashfs` or `.sqfs`?

   I'm currently picking `sqfs`.

    There is not canonical extension for squashfs, but there are two semi-official ones:
    - `.squashfs`: The most popular one from a quick search on GitHub. Also used by some distros.
     https://github.com/NixOS/nixpkgs/blob/6576d979e9a64d870b1f298a5c598116891a6c25/nixos/modules/installer/cd-dvd/iso-image.nix#L797
    - `.sqfs`: Mentioned in `man mksquashfs` by squashfs-tools, the reference implementation.
      https://github.com/plougher/squashfs-tools/blob/9f9bbd79016ff04967800f4301c7a9d0024c0c91/Documentation/manpages/mksquashfs.1#L494

3. `backhand` depends [`liblzma`](https://crates.io/crates/liblzma), a maintained `xz2` fork, which conflicts with our dependency `xz2`. I disabled the Xz support of `backhand` to mitigate this. How can we fix this?

4. How to pass compression options for squashfs compressor? It is done inside squashfs format (per-chunk compression) thus does not use chained formats. We probably need a new CLI argument for it.

5. Currently, during compression, it buffers the whole squashfs in memory but we can write directly into file (which supports `Seek`). We did a special case in decompression, but it causes some code duplication and we does not do this for Zip compression either. Is there a better way to do so, or should we also add a special case in compression?

6. Do we want streaming compression support `.sqfs.zstd` (archive-then-compress instead or compress-per-chunk)? It could be done using some tricks like reserving spaces and emit [ZSTD Literal Frame](https://github.com/facebook/zstd/blob/1dbc2e09084e843f6c0dcc2d0791610015c50979/doc/zstd_compression_format.md#literals-section). Not sure about other compression formats. I don't think we want to support this, at least for now, given that decompression cannot be streamed anyway.

7. How should we support multiple input paths? Typically squashfs has a single "root directory". Currently, it reports an error if the input is not a single path to a directory. It would be weird to either "merge" all paths into one tree, or put multiple directory under the root directory (What mode/permission should the root use? Surprising behavior difference between one and more than one paths.).