### PR TITLE
feat: Replace `liblzma` with `lzma-rust2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,13 @@ Categories Used:
 - Provide Nushell completions (packages still need to install them) [\#827](https://github.com/ouch-org/ouch/pull/827) ([FrancescElies](https://github.com/FrancescElies))
 - Support `.lz` decompression [\#838](https://github.com/ouch-org/ouch/pull/838) ([zzzsyyy](https://github.com/zzzsyyy))
 - Support `.lzma` decompression (and fix `.lzma` being a wrong alias for `.xz`) [\#838](https://github.com/ouch-org/ouch/pull/838) ([zzzsyyy](https://github.com/zzzsyyy))
+- Support `.lz` compression [\#863](https://github.com/ouch-org/ouch/pull/863) ([sorairolake](https://github.com/sorairolake))
 
 ### Improvements
 
 - Give better error messages when archive extensions are invalid [\#817](https://github.com/ouch-org/ouch/pull/817) ([marcospb19](https://github.com/marcospb19))
 - Add aliases for `--password` flag (`--pass` and `--pw`) [\#847](https://github.com/ouch-org/ouch/pull/847) ([marcospb19](https://github.com/marcospb19))
+- Use `lzma-rust2` crate instead of `liblzma` crate [\#865](https://github.com/ouch-org/ouch/pull/865) ([sorairolake](https://github.com/sorairolake))
 
 ### Bug Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,6 +477,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,26 +942,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "liblzma"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0791ab7e08ccc8e0ce893f6906eb2703ed8739d8e89b57c0714e71bad09024c8"
-dependencies = [
- "liblzma-sys",
-]
-
-[[package]]
-name = "liblzma-sys"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b9596486f6d60c3bbe644c0e1be1aa6ccc472ad630fe8927b456973d7cb736"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,6 +1008,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "561d131e2d9b07641ac55bc35de5ae4ac3e783fdeebd3c4c1dd3b6a7b920051a"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "lzma-rust2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c60a23ffb90d527e23192f1246b14746e2f7f071cb84476dd879071696c18a4a"
+dependencies = [
+ "crc",
+ "sha2",
 ]
 
 [[package]]
@@ -1124,9 +1129,9 @@ dependencies = [
  "is_executable",
  "itertools",
  "libc",
- "liblzma",
  "linked-hash-map",
  "lz4_flex",
+ "lzma-rust2 0.13.0",
  "memchr",
  "num_cpus",
  "once_cell",
@@ -1558,7 +1563,7 @@ dependencies = [
  "filetime_creation",
  "getrandom 0.3.1",
  "js-sys",
- "lzma-rust2",
+ "lzma-rust2 0.2.0",
  "nt-time",
  "sha2",
  "wasm-bindgen",
@@ -1577,9 +1582,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = [
     "Vinícius Rodrigues Miguel <vrmiguel99@gmail.com>",
 ]
 edition = "2021"
+rust-version = "1.82.0"
 readme = "README.md"
 repository = "https://github.com/ouch-org/ouch"
 license = "MIT"
@@ -31,6 +32,7 @@ ignore = "0.4.23"
 libc = "0.2.155"
 linked-hash-map = "0.5.6"
 lz4_flex = "0.11.3"
+lzma-rust2 = "0.13.0"
 num_cpus = "1.16.0"
 once_cell = "1.20.2"
 rayon = "1.10.0"
@@ -41,7 +43,6 @@ tar = "0.4.42"
 tempfile = "3.10.1"
 time = { version = "0.3.36", default-features = false }
 unrar = { version = "0.5.7", optional = true }
-liblzma = "0.4"
 zip = { version = "0.6.6", default-features = false, features = [
     "time",
     "aes-crypto",

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Output:
 
 | Format    | `.tar` | `.zip` | `7z` | `.gz` | `.xz` | `.lzma` | `.lz` | `.bz`, `.bz2` | `.bz3` | `.lz4` | `.sz` (Snappy) | `.zst` | `.rar` | `.br` |
 |:---------:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| Supported | ✓ | ✓¹ | ✓¹ | ✓² | ✓ | ✓⁴ | ✓⁴ | ✓ | ✓ | ✓ | ✓² | ✓² | ✓³ | ✓ |
+| Supported | ✓ | ✓¹ | ✓¹ | ✓² | ✓ | ✓⁴ | ✓ | ✓ | ✓ | ✓ | ✓² | ✓² | ✓³ | ✓ |
 
 ✓: Supports compression and decompression.
 
@@ -189,7 +189,6 @@ If you're downloading binaries from the [releases page](https://github.com/ouch-
 
 Otherwise, you'll need these libraries installed on your system:
 
-* [liblzma](https://www.7-zip.org/sdk.html)
 * [libbz2](https://www.sourceware.org/bzip2)
 * [libbz3](https://github.com/kspalaiologos/bzip3)
 * [libz](https://www.zlib.net)

--- a/src/commands/decompress.rs
+++ b/src/commands/decompress.rs
@@ -128,15 +128,9 @@ pub fn decompress_file(options: DecompressOptions) -> crate::Result<()> {
                 Box::new(bzip3::read::Bz3Decoder::new(decoder)?)
             }
             Lz4 => Box::new(lz4_flex::frame::FrameDecoder::new(decoder)),
-            Lzma => Box::new(liblzma::read::XzDecoder::new_stream(
-                decoder,
-                liblzma::stream::Stream::new_lzma_decoder(u64::MAX).unwrap(),
-            )),
-            Xz => Box::new(liblzma::read::XzDecoder::new(decoder)),
-            Lzip => Box::new(liblzma::read::XzDecoder::new_stream(
-                decoder,
-                liblzma::stream::Stream::new_lzip_decoder(u64::MAX, 0).unwrap(),
-            )),
+            Lzma => Box::new(lzma_rust2::LzmaReader::new_mem_limit(decoder, u32::MAX, None)?),
+            Xz => Box::new(lzma_rust2::XzReader::new(decoder, true)),
+            Lzip => Box::new(lzma_rust2::LzipReader::new(decoder)?),
             Snappy => Box::new(snap::read::FrameDecoder::new(decoder)),
             Zstd => Box::new(zstd::stream::Decoder::new(decoder)?),
             Brotli => Box::new(brotli::Decompressor::new(decoder, BUFFER_CAPACITY)),

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -57,15 +57,9 @@ pub fn list_archive_contents(
                     Box::new(bzip3::read::Bz3Decoder::new(decoder).unwrap())
                 }
                 Lz4 => Box::new(lz4_flex::frame::FrameDecoder::new(decoder)),
-                Lzma => Box::new(liblzma::read::XzDecoder::new_stream(
-                    decoder,
-                    liblzma::stream::Stream::new_lzma_decoder(u64::MAX).unwrap(),
-                )),
-                Xz => Box::new(liblzma::read::XzDecoder::new(decoder)),
-                Lzip => Box::new(liblzma::read::XzDecoder::new_stream(
-                    decoder,
-                    liblzma::stream::Stream::new_lzip_decoder(u64::MAX, 0).unwrap(),
-                )),
+                Lzma => Box::new(lzma_rust2::LzmaReader::new_mem_limit(decoder, u32::MAX, None)?),
+                Xz => Box::new(lzma_rust2::XzReader::new(decoder, true)),
+                Lzip => Box::new(lzma_rust2::LzipReader::new(decoder)?),
                 Snappy => Box::new(snap::read::FrameDecoder::new(decoder)),
                 Zstd => Box::new(zstd::stream::Decoder::new(decoder)?),
                 Brotli => Box::new(brotli::Decompressor::new(decoder, BUFFER_CAPACITY)),

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -94,7 +94,7 @@ pub enum CompressionFormat {
     Lzip,
     /// .sz
     Snappy,
-    /// tar, tgz, tbz, tbz2, tbz3, txz, tlz4, tlzma, tsz, tzst
+    /// tar, tgz, tbz, tbz2, tbz3, txz, tlz, tlz4, tlzma, tsz, tzst
     Tar,
     /// .zst
     Zstd,

--- a/src/utils/formatting.rs
+++ b/src/utils/formatting.rs
@@ -45,11 +45,11 @@ impl Display for EscapedPathDisplay<'_> {
 /// This is different from [`Path::display`].
 ///
 /// See <https://gist.github.com/marcospb19/ebce5572be26397cf08bbd0fd3b65ac1> for a comparison.
-pub fn path_to_str(path: &Path) -> Cow<str> {
+pub fn path_to_str(path: &Path) -> Cow<'_, str> {
     os_str_to_str(path.as_ref())
 }
 
-pub fn os_str_to_str(os_str: &OsStr) -> Cow<str> {
+pub fn os_str_to_str(os_str: &OsStr) -> Cow<'_, str> {
     let format = || {
         let text = format!("{os_str:?}");
         Cow::Owned(text.trim_matches('"').to_string())
@@ -83,7 +83,7 @@ pub fn pretty_format_list_of_paths(paths: &[impl AsRef<Path>]) -> String {
 }
 
 /// Display the directory name, but use "current directory" when necessary.
-pub fn nice_directory_display(path: &Path) -> Cow<str> {
+pub fn nice_directory_display(path: &Path) -> Cow<'_, str> {
     if path == Path::new(".") {
         Cow::Borrowed("current directory")
     } else {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -32,6 +32,7 @@ enum DirectoryExtension {
     #[cfg(feature = "bzip3")]
     Tbz3,
     Tgz,
+    Tlz,
     Tlz4,
     Tsz,
     Txz,
@@ -48,6 +49,7 @@ enum FileExtension {
     #[cfg(feature = "bzip3")]
     Bz3,
     Gz,
+    Lz,
     Lz4,
     Sz,
     Xz,


### PR DESCRIPTION
<!--
If your code changes text output, you might need to update snapshots
of UI tests, read more about `insta` at CONTRIBUTING.md.

Remember to edit `CHANGELOG.md` after opening the PR.
-->
Replace the LZMA implementation from bindings to the `liblzma` to a pure Rust implementation.

I'll mark this as ready for review after #863 is merged.

Closes #864