### PR TITLE
Breaking change: remove auto-flattening feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Categories Used:
 
 ## [Unreleased](https://github.com/ouch-org/ouch/compare/0.6.1...HEAD)
 
+### Breaking Changes
+
+- Remove archive auto-flattening on decompression (formerly known as "smart unpack") (https://github.com/ouch-org/ouch/pull/907)
+
 ### New Features
 
 - Merge folders in decompression (https://github.com/ouch-org/ouch/pull/798)

--- a/src/check.rs
+++ b/src/check.rs
@@ -31,8 +31,6 @@ pub fn check_mime_type(
         // File with no extension
         // Try to detect it automatically and prompt the user about it
         if let Some(detected_format) = try_infer_extension(path) {
-            // Inferring the file extension can have unpredicted consequences (e.g. the user just
-            // mistyped, ...) which we should always inform the user about.
             warning!(
                 "We detected a file named `{}`, do you want to decompress it?",
                 path.display(),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -116,10 +116,6 @@ pub fn run(
             );
 
             if let Ok(true) = compress_result {
-                // this is only printed once, so it doesn't result in much text. On the other hand,
-                // having a final status message is important especially in an accessibility context
-                // as screen readers may not read a commands exit code, making it hard to reason
-                // about whether the command succeeded without such a message
                 info_accessible!("Successfully compressed '{}'", path_to_str(&output_path));
             } else {
                 // If Ok(false) or Err() occurred, delete incomplete file at `output_path`
@@ -180,7 +176,6 @@ pub fn run(
 
             // The directory that will contain the output files
             // We default to the current directory if the user didn't specify an output directory with --dir
-            let is_output_dir_provided = output_dir.is_some();
             let output_dir = if let Some(dir) = output_dir {
                 utils::create_dir_if_non_existent(&dir)?;
                 dir
@@ -204,7 +199,6 @@ pub fn run(
                         formats,
                         output_dir: &output_dir,
                         output_file_path,
-                        is_output_dir_provided,
                         question_policy,
                         password: args.password.as_deref().map(|str| {
                             <[u8] as ByteSlice>::from_os_str(str).expect("convert password to bytes failed")

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -98,8 +98,6 @@ pub fn rename_or_increment_filename(path: &Path) -> PathBuf {
 pub fn create_dir_if_non_existent(path: &Path) -> crate::Result<()> {
     if !path.exists() {
         fs::create_dir_all(path)?;
-        // creating a directory is an important change to the file system we
-        // should always inform the user about
         info_accessible!("Directory {} created", EscapedPathDisplay::new(path));
     }
     Ok(())

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -376,50 +376,6 @@ fn multiple_files_with_conflict_and_choice_to_rename_with_already_a_renamed(
     assert_same_directory(src_files_path, dest_files_path_renamed.join("src_files"), false);
 }
 
-#[proptest(cases = 25)]
-fn multiple_files_with_disabled_smart_unpack_by_dir(
-    ext: DirectoryExtension,
-    #[any(size_range(0..1).lift())] extra_extensions: Vec<FileExtension>,
-) {
-    let temp_dir = tempdir().unwrap();
-    let root_path = temp_dir.path();
-
-    let src_files_path = root_path.join("src_files");
-    fs::create_dir_all(&src_files_path).unwrap();
-
-    let files_path = ["file1.txt", "file2.txt", "file3.txt", "file4.txt", "file5.txt"]
-        .into_iter()
-        .map(|f| src_files_path.join(f))
-        .inspect(|path| {
-            let mut file = fs::File::create(path).unwrap();
-            file.write_all("Some content".as_bytes()).unwrap();
-        })
-        .collect::<Vec<_>>();
-
-    let dest_files_path = root_path.join("dest_files");
-    fs::create_dir_all(&dest_files_path).unwrap();
-
-    let archive = &root_path.join(format!("archive.{}", merge_extensions(ext, &extra_extensions)));
-
-    crate::utils::cargo_bin()
-        .arg("compress")
-        .args(files_path)
-        .arg(archive)
-        .assert()
-        .success();
-
-    crate::utils::cargo_bin()
-        .arg("decompress")
-        .arg(archive)
-        .arg("-d")
-        .arg(&dest_files_path)
-        .write_stdin("r")
-        .assert()
-        .success();
-
-    assert_same_directory(src_files_path, dest_files_path, false);
-}
-
 #[cfg(feature = "unrar")]
 #[test]
 fn unpack_rar() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
Previously called "smart unpack", all this feature did was automatically flatten the top-level directory of an archive when decompressing an archive with a single element in its root

It's being removed right now for being unpredictable, might be re-added in the future with flags or config file, basically, something that makes it opt-in and not the default

<!--
If your code changes text output, you might need to update snapshots
of UI tests, read more about `insta` at CONTRIBUTING.md.

Remember to edit `CHANGELOG.md` after opening the PR.
-->
