### PR TITLE
fix: show "Directory ... created" instead of misleading byte size

### DIFF
--- a/src/archive/tar.rs
+++ b/src/archive/tar.rs
@@ -80,11 +80,12 @@ pub fn unpack_archive(reader: impl Read, output_folder: &Path) -> Result<u64> {
             _ => continue,
         }
 
-        info!(
-            "extracted ({}) {}",
-            BytesFmt(entry.size()),
-            PathFmt(&output_folder.join(entry.path()?)),
-        );
+        let full_path = output_folder.join(entry.path()?);
+        if entry.header().entry_type().is_dir() {
+            info!("Directory {} created", PathFmt(&full_path));
+        } else {
+            info!("extracted ({}) {}", BytesFmt(entry.size()), PathFmt(&full_path));
+        }
         files_unpacked += 1;
     }
 

--- a/src/archive/zip.rs
+++ b/src/archive/zip.rs
@@ -53,7 +53,7 @@ where
 
         match file.name().ends_with('/') {
             _is_dir @ true => {
-                info!("File {} extracted to {}", idx, PathFmt(&file_path));
+                info!("Directory {} created", PathFmt(&file_path));
 
                 let mode = file.unix_mode();
                 let is_symlink = mode.is_some_and(|mode| mode & 0o170000 == 0o120000);

--- a/tests/snapshots/ui__ui_test_ok_decompress_multiple_files.snap
+++ b/tests/snapshots/ui__ui_test_ok_decompress_multiple_files.snap
@@ -2,9 +2,9 @@
 source: tests/ui.rs
 expression: "lines.join(\"\\n\")"
 ---
+[INFO] Directory "output/input" created
 [INFO] Files unpacked: 4
 [INFO] Successfully decompressed archive to "output"
-[INFO] extracted ( [SIZE]) "output/input"
 [INFO] extracted ( [SIZE]) "output/input/input"
 [INFO] extracted ( [SIZE]) "output/input/input2"
 [INFO] extracted ( [SIZE]) "output/input/input3"


### PR DESCRIPTION
## Summary

Unifies directory output messages across tar and zip archive unpacking.

## Why this matters

When unpacking archives, directory entries showed confusing output:
- **zip** (`src/archive/zip.rs:56`): `"File 12 extracted to \"src/commands/\""` - directories aren't files
- **tar** (`src/archive/tar.rs:83`): `"extracted (0 B) \"src/commands\""` - the 0 B size is misleading

Both should show the same clear message indicating a directory was created.

## Changes

- `src/archive/zip.rs`: Changed directory branch to print `"Directory {path} created"` instead of `"File {idx} extracted to {path}"`
- `src/archive/tar.rs`: Added `entry.header().entry_type().is_dir()` check so directories print `"Directory {path} created"` while regular files keep the existing `"extracted ({bytes}) {path}"` format
- Updated snapshot test to match the new output

## Testing

`cargo test` passes (13/13 tests). Snapshot updated for `ui_test_ok_decompress_multiple_files`.

Fixes #328

This contribution was developed with AI assistance (Claude Code).