### PR TITLE
fix multiple panics on extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,13 @@ Categories Used:
 
 ### Improvements
 
+- Report mtime-set errors for `.7z` as warnings (https://github.com/ouch-org/ouch/pull/950)
+
 ### Bug Fixes
 
-### Tweaks
+- Fix various panics not handled gracefully (https://github.com/ouch-org/ouch/pull/950)
 
+### Tweaks
 
 ## [0.7.0](https://github.com/ouch-org/ouch/releases/tag/0.7.0)
 

--- a/src/archive/sevenz.rs
+++ b/src/archive/sevenz.rs
@@ -50,13 +50,15 @@ where
                 io::copy(reader, &mut writer)?;
 
                 use filetime_creation as ft;
-                ft::set_file_handle_times(
+                // Surface mtime-set failures as warnings so users know timestamps weren't preserved
+                if let Err(e) = ft::set_file_handle_times(
                     writer.get_ref().file(),
                     Some(ft::FileTime::from_system_time(entry.access_date().into())),
                     Some(ft::FileTime::from_system_time(entry.last_modified_date().into())),
                     Some(ft::FileTime::from_system_time(entry.creation_date().into())),
-                )
-                .unwrap_or_default();
+                ) {
+                    warning!("could not set timestamps on {}: {e}", PathFmt(&file_path));
+                }
             }
 
             files_unpacked += 1;

--- a/src/archive/tar.rs
+++ b/src/archive/tar.rs
@@ -150,7 +150,7 @@ where
         let iter = file_visibility_policy.workaround_build_walker_or_broken_link_path(explicit_path, filename);
 
         for entry in iter {
-            let path = entry.unwrap();
+            let path = entry?;
 
             // Avoid compressing the output file into itself
             if let Ok(handle) = output_handle.as_ref()

--- a/src/check.rs
+++ b/src/check.rs
@@ -257,8 +257,7 @@ pub fn check_invalid_compression_with_non_archive_format(
             format!("From: --format {formats}"),
             format!("To:   --format tar.{formats}"),
         )
-    } else if let Some(suggested_output_path) = build_archive_file_suggestion(output_path, ".tar")
-    {
+    } else if let Some(suggested_output_path) = build_archive_file_suggestion(output_path, ".tar") {
         // This piece of code creates a suggestion for compressing multiple files
         // It says:
         // Change from file.bz.xz

--- a/src/check.rs
+++ b/src/check.rs
@@ -257,17 +257,23 @@ pub fn check_invalid_compression_with_non_archive_format(
             format!("From: --format {formats}"),
             format!("To:   --format tar.{formats}"),
         )
-    } else {
+    } else if let Some(suggested_output_path) = build_archive_file_suggestion(output_path, ".tar")
+    {
         // This piece of code creates a suggestion for compressing multiple files
         // It says:
         // Change from file.bz.xz
         // To          file.tar.bz.xz
-        let suggested_output_path = build_archive_file_suggestion(output_path, ".tar")
-            .expect("output path should contain a compression format");
-
         (
             format!("From: {}", PathFmt(output_path)),
             format!("To:   \"{suggested_output_path}\""),
+        )
+    } else {
+        // Could not build a suggestion (output path has no recognized compression extension)
+        // Fall back to generic hints
+        (
+            format!("From: {}", PathFmt(output_path)),
+            "To:   insert an archive format like '.tar.', '.zip.' or '.7z.' before the compression extension"
+                .to_string(),
         )
     };
 

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -54,7 +54,7 @@ pub fn list_archive_contents(
                     return Err(crate::Error::bzip3_no_support());
 
                     #[cfg(feature = "bzip3")]
-                    Box::new(bzip3::read::Bz3Decoder::new(decoder).unwrap())
+                    Box::new(bzip3::read::Bz3Decoder::new(decoder)?)
                 }
                 Lz4 => Box::new(MultiFrameLz4Decoder::new(decoder)),
                 Lzma => Box::new(lzma_rust2::LzmaReader::new_mem_limit(decoder, u32::MAX, None)?),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -49,11 +49,12 @@ fn warn_user_about_loading_sevenz_in_memory() {
 ///
 /// There are a lot of custom errors to give enough error description and explanation.
 pub fn run(args: CliArgs, question_policy: QuestionPolicy, file_visibility_policy: FileVisibilityPolicy) -> Result<()> {
-    if let Some(threads) = args.threads {
+    // Skip --threads 0 ("auto") to match cli::mod.rs, and propagate pool-init errors
+    if let Some(threads) = args.threads.filter(|&t| t != 0) {
         rayon::ThreadPoolBuilder::new()
             .num_threads(threads)
             .build_global()
-            .unwrap();
+            .map_err(|e| FinalError::with_title("Failed to initialize thread pool").detail(e.to_string()))?;
     }
 
     match args.cmd {

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -30,7 +30,7 @@ pub const SUPPORTED_EXTENSIONS: &[&str] = &[
 ];
 
 pub const SUPPORTED_ALIASES: &[&str] = &[
-    "tgz", "tbz", "tlz4", "txz", "tzlma", "tsz", "tzst", "tlz", "cbt", "cbz", "cb7", "cbr",
+    "tgz", "tbz", "tlz4", "txz", "tlzma", "tsz", "tzst", "tlz", "cbt", "cbz", "cb7", "cbr",
 ];
 
 #[cfg(not(feature = "unrar"))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,13 @@ pub const EXIT_FAILURE: i32 = libc::EXIT_FAILURE;
 
 /// Current directory, canonicalized for consistent path comparisons across platforms
 static INITIAL_CURRENT_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
-    let dir = env::current_dir().expect("can't read current directory");
-    utils::canonicalize(&dir).expect("can't canonicalize current directory")
+    // Bail out cleanly rather than panicking if the CWD has been deleted or is unreadable
+    let bail = |err: &dyn std::fmt::Display| -> ! {
+        eprintln!("ouch: cannot read current directory: {err}");
+        std::process::exit(EXIT_FAILURE);
+    };
+    let dir = env::current_dir().unwrap_or_else(|e| bail(&e));
+    utils::canonicalize(&dir).unwrap_or_else(|e| bail(&e))
 });
 
 fn main() {


### PR DESCRIPTION
A few bugs that cause panics or silently lose info

- `ouch list` panics on a corrupt `.bz3` file because `Bz3Decoder::new` is called with `.unwrap()`. `decompress.rs` already uses `?` for the same call.
- Tar compression panics if the file walker hits an I/O or permission error mid-walk (`entry.unwrap()` in `archive/tar.rs`). Zip and 7z already use `?`.
- 7z extraction silently drops mtime-set errors via `.unwrap_or_default()`, so users get files with wrong timestamps and no warning.
- Typo in `SUPPORTED_ALIASES`: `"tzlma"` should be `"tlzma"` (every other place in the codebase uses `tlzma`).
- `ouch` panics at startup if the current directory is unreadable or has been deleted (`env::current_dir().expect(...)` in `main.rs`).
- `--threads 0` is handled inconsistently: `cli/mod.rs` treats it as "auto" but `commands/mod.rs` still passes it to rayon, and `build_global().unwrap()` panics if the thread pool is already initialized.
- `ouch compress input1.txt input2.txt archive.bz3 --yes` panics with "output path should contain a compression format" at `src/check.rs`