### PR TITLE
Fix trailing slashes when listing Zip directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Categories Used:
 ### Bug Fixes
 
 - Fix various panics not handled gracefully (https://github.com/ouch-org/ouch/pull/950)
+- Fix directory display with trailing slashes in list output (https://github.com/ouch-org/ouch/commit/de22cbc)
 
 ### Tweaks
 

--- a/src/list.rs
+++ b/src/list.rs
@@ -99,14 +99,15 @@ fn print_entry(out: &mut impl Write, name: impl fmt::Display, file_type: &ListFi
         }
         ListFileType::Directory => {
             let name_str = name.to_string();
-            let display_name = name_str.strip_suffix('/').unwrap_or(&name_str);
+            // Strip trailing slashes so we can consistently re-add one when needed.
+            let display_name = name_str.trim_end_matches('/');
 
             let output = if BLUE.is_empty() {
-                // Colors are deactivated, print final / to mark directories
+                // Colors deactivated, print final / to mark directories
                 format!("{display_name}/")
             } else if is_running_in_accessible_mode() {
-                // Accessible mode: use colors but print final / for screen readers
-                format!("{}{}{}/{}", *BLUE, *STYLE_BOLD, display_name, *ALL_RESET)
+                // Accessible mode: colors + trailing / for screen readers
+                format!("{}{}{display_name}/{}", *BLUE, *STYLE_BOLD, *ALL_RESET)
             } else {
                 // Normal mode: use colors without trailing slash
                 format!("{}{}{}{}", *BLUE, *STYLE_BOLD, display_name, *ALL_RESET)


### PR DESCRIPTION
Fix #807

