### PR TITLE
Use cargo build --locked

### DIFF
--- a/.github/workflows/build-artifacts-and-run-tests.yml
+++ b/.github/workflows/build-artifacts-and-run-tests.yml
@@ -158,7 +158,7 @@ jobs:
         # there's no way to run tests for ARM64 Windows for now
         if: matrix.target != 'aarch64-pc-windows-msvc'
         run: |
-          ${{ env.CARGO }} +stable test --profile fast --target ${{ matrix.target }} $EXTRA_CARGO_FLAGS
+          ${{ env.CARGO }} +stable test --locked --profile fast --target ${{ matrix.target }} $EXTRA_CARGO_FLAGS
 
       - name: Build release artifacts (binary and completions)
         if: ${{ inputs.artifact_upload_mode != 'none' }}

--- a/.github/workflows/build-artifacts-and-run-tests.yml
+++ b/.github/workflows/build-artifacts-and-run-tests.yml
@@ -163,7 +163,7 @@ jobs:
       - name: Build release artifacts (binary and completions)
         if: ${{ inputs.artifact_upload_mode != 'none' }}
         run: |
-          ${{ env.CARGO }} +stable build --release --target ${{ matrix.target }} $EXTRA_CARGO_FLAGS
+          ${{ env.CARGO }} +stable build --locked --release --target ${{ matrix.target }} $EXTRA_CARGO_FLAGS
         env:
           OUCH_ARTIFACTS_FOLDER: man-page-and-completions-artifacts
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,7 +1158,7 @@ checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "ouch"
-version = "0.6.1"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "assert_cmd",


### PR DESCRIPTION
<!--
If your code changes text output, you might need to update snapshots
of UI tests, read more about `insta` at CONTRIBUTING.md.

Remember to edit `CHANGELOG.md` after opening the PR.
-->

the 0.7.1 version of ouch has an outdated lockfile, see https://github.com/conda-forge/ouch-feedstock/pull/9

Would be nice to catch this early