### PR TITLE
CI: use `--release` for tests in release job

### DIFF
--- a/.github/workflows/build-artifacts-and-run-tests.yml
+++ b/.github/workflows/build-artifacts-and-run-tests.yml
@@ -146,19 +146,29 @@ jobs:
           if [[ -n "$FEATURES" ]]; then FLAGS+=" --features $FEATURES"; fi
           echo "EXTRA_CARGO_FLAGS=$FLAGS" >> $GITHUB_ENV
 
+      - name: Set test profile
+        id: test-profile
+        shell: bash
+        run: |
+          if [[ "${{ inputs.artifact_upload_mode }}" == "none" ]]; then
+            echo "profile=--profile fast" >> $GITHUB_OUTPUT
+          else
+            echo "profile=--release" >> $GITHUB_OUTPUT
+          fi
+
       - name: Install Rust
         run: |
           rustup toolchain install stable --profile minimal -t ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2
         with:
-          key: "${{ matrix.target }}-${{ matrix.feature-unrar }}-${{ matrix.feature-use-zlib }}-${{ matrix.feature-use-zstd-thin }}-${{ matrix.feature-bzip3 }}"
+          key: "${{ matrix.target }}-${{ matrix.feature-unrar }}-${{ matrix.feature-use-zlib }}-${{ matrix.feature-use-zstd-thin }}-${{ matrix.feature-bzip3 }}-${{ steps.test-profile.outputs.profile }}"
 
       - name: Test on stable
         # there's no way to run tests for ARM64 Windows for now
         if: matrix.target != 'aarch64-pc-windows-msvc'
         run: |
-          ${{ env.CARGO }} +stable test --locked --profile fast --target ${{ matrix.target }} $EXTRA_CARGO_FLAGS
+          ${{ env.CARGO }} +stable test --locked ${{ steps.test-profile.outputs.profile }} --target ${{ matrix.target }} $EXTRA_CARGO_FLAGS
 
       - name: Build release artifacts (binary and completions)
         if: ${{ inputs.artifact_upload_mode != 'none' }}

--- a/.github/workflows/build-artifacts-and-run-tests.yml
+++ b/.github/workflows/build-artifacts-and-run-tests.yml
@@ -151,9 +151,9 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ inputs.artifact_upload_mode }}" == "none" ]]; then
-            echo "profile=--profile fast" >> $GITHUB_OUTPUT
+            echo "profile=fast" >> $GITHUB_OUTPUT
           else
-            echo "profile=--release" >> $GITHUB_OUTPUT
+            echo "profile=release" >> $GITHUB_OUTPUT
           fi
 
       - name: Install Rust
@@ -168,7 +168,7 @@ jobs:
         # there's no way to run tests for ARM64 Windows for now
         if: matrix.target != 'aarch64-pc-windows-msvc'
         run: |
-          ${{ env.CARGO }} +stable test --locked ${{ steps.test-profile.outputs.profile }} --target ${{ matrix.target }} $EXTRA_CARGO_FLAGS
+          ${{ env.CARGO }} +stable test --locked --profile ${{ steps.test-profile.outputs.profile }} --target ${{ matrix.target }} $EXTRA_CARGO_FLAGS
 
       - name: Build release artifacts (binary and completions)
         if: ${{ inputs.artifact_upload_mode != 'none' }}


### PR DESCRIPTION
Previously, the release job used to compile with `--profile fast` and then `--release`.

To ensure the binaries tested are the same as the ones which will be released (and decrease time compiling), also perform tests with `--release`.