### PR TITLE
perf(rar): switch to unrar-ng batch extract_all_with_callback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,9 +1837,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unrar-ng"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce040dcf1c5a2ffa16abc251813a0766fdf753afe468d6015800368cf1913b07"
+checksum = "7881a7cefee603cdd23e6acd424ee62c64e088d39688f60d20649d978de55f41"
 dependencies = [
  "bitflags",
  "regex",
@@ -1849,9 +1849,9 @@ dependencies = [
 
 [[package]]
 name = "unrar-ng-sys"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a121a227a18dfd67638398304b5a0544c7e328912d0c314cd2f80b4b504b51a7"
+checksum = "afa06861a15d69012d3c1035510e9ca416031ae37b6d27bb7e3ab1a2984e1230"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,7 +1197,7 @@ dependencies = [
  "tempfile",
  "test-strategy",
  "time",
- "unrar",
+ "unrar-ng",
  "zip",
  "zstd",
 ]
@@ -1836,22 +1836,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unrar"
-version = "0.5.8"
+name = "unrar-ng"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ec61343a630d2b50d13216dea5125e157d3fc180a7d3f447d22fe146b648fc"
+checksum = "2846729dd791bdcc5d65d30130808e9d75661ca75dc92dea4fea1614b4f7bd50"
 dependencies = [
  "bitflags",
  "regex",
- "unrar_sys",
+ "unrar-ng-sys",
  "widestring",
 ]
 
 [[package]]
-name = "unrar_sys"
-version = "0.5.8"
+name = "unrar-ng-sys"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b77675b883cfbe6bf41e6b7a5cd6008e0a83ba497de3d96e41a064bbeead765"
+checksum = "4b5cbe5d90923c67a24c1337c80a7478d93f9c5999ab3d7008a70678d60bad68"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,9 +1837,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unrar-ng"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2846729dd791bdcc5d65d30130808e9d75661ca75dc92dea4fea1614b4f7bd50"
+checksum = "ce040dcf1c5a2ffa16abc251813a0766fdf753afe468d6015800368cf1913b07"
 dependencies = [
  "bitflags",
  "regex",
@@ -1849,9 +1849,9 @@ dependencies = [
 
 [[package]]
 name = "unrar-ng-sys"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b5cbe5d90923c67a24c1337c80a7478d93f9c5999ab3d7008a70678d60bad68"
+checksum = "a121a227a18dfd67638398304b5a0544c7e328912d0c314cd2f80b4b504b51a7"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ strum = { version = "0.28.0", features = ["derive"] }
 tar = "0.4.45"
 tempfile = "3.27.0"
 time = { version = "0.3.47", default-features = false }
-unrar = { package = "unrar-ng", version = "0.7.4", optional = true }
+unrar = { package = "unrar-ng", version = "0.7.5", optional = true }
 zip = { version = "8.6.0", default-features = false, features = [
     "time",
     "aes-crypto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ strum = { version = "0.28.0", features = ["derive"] }
 tar = "0.4.45"
 tempfile = "3.27.0"
 time = { version = "0.3.47", default-features = false }
-unrar = { package = "unrar-ng", version = "0.7.5", optional = true }
+unrar = { package = "unrar-ng", version = "0.7.6", optional = true }
 zip = { version = "8.6.0", default-features = false, features = [
     "time",
     "aes-crypto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ strum = { version = "0.28.0", features = ["derive"] }
 tar = "0.4.45"
 tempfile = "3.27.0"
 time = { version = "0.3.47", default-features = false }
-unrar = { version = "0.5.8", optional = true }
+unrar = { package = "unrar-ng", version = "0.7.4", optional = true }
 zip = { version = "8.6.0", default-features = false, features = [
     "time",
     "aes-crypto",

--- a/src/archive/rar.rs
+++ b/src/archive/rar.rs
@@ -26,15 +26,10 @@ pub fn unpack_archive(archive_path: &Path, output_folder: &Path, password: Optio
 
     let mut files_unpacked: u64 = 0;
     let mut first_err: Option<(PathBuf, i32)> = None;
-    let mut pending_size: u64 = 0;
 
     let cb_result = archive.extract_all_with_callback(output_folder, |event| match event {
-        ExtractEvent::Start { size, .. } => {
-            pending_size = size;
-            true
-        }
-        ExtractEvent::Ok { filename } => {
-            info!("extracted ({}) {}", BytesFmt(pending_size), filename.display());
+        ExtractEvent::Ok { filename, size } => {
+            info!("extracted ({}) {}", BytesFmt(size), filename.display());
             files_unpacked += 1;
             true
         }

--- a/src/archive/rar.rs
+++ b/src/archive/rar.rs
@@ -26,13 +26,15 @@ pub fn unpack_archive(archive_path: &Path, output_folder: &Path, password: Optio
 
     let mut files_unpacked: u64 = 0;
     let mut first_err: Option<(PathBuf, i32)> = None;
+    let mut pending_size: u64 = 0;
 
     let cb_result = archive.extract_all_with_callback(output_folder, |event| match event {
-        ExtractEvent::Start { filename, size } => {
-            info!("extracted ({}) {}", BytesFmt(size), filename.display());
+        ExtractEvent::Start { size, .. } => {
+            pending_size = size;
             true
         }
-        ExtractEvent::Ok { .. } => {
+        ExtractEvent::Ok { filename } => {
+            info!("extracted ({}) {}", BytesFmt(pending_size), filename.display());
             files_unpacked += 1;
             true
         }

--- a/src/archive/rar.rs
+++ b/src/archive/rar.rs
@@ -11,7 +11,7 @@ use crate::{
     error::{Error, FinalError, Result},
     info,
     list::{FileInArchive, ListFileType},
-    utils::BytesFmt,
+    utils::{BytesFmt, PathFmt},
 };
 
 /// Unpacks the archive given by `archive_path` into the folder given by `output_folder`.
@@ -29,7 +29,7 @@ pub fn unpack_archive(archive_path: &Path, output_folder: &Path, password: Optio
 
     let cb_result = archive.extract_all_with_callback(output_folder, |event| match event {
         ExtractEvent::Ok { filename, size } => {
-            info!("extracted ({}) {}", BytesFmt(size), filename.display());
+            info!("extracted ({}) {}", BytesFmt(size), PathFmt(&filename));
             files_unpacked += 1;
             true
         }
@@ -58,7 +58,7 @@ pub fn unpack_archive(archive_path: &Path, output_folder: &Path, password: Optio
     if let Some((path, code)) = first_err {
         let inner = UnrarError::from(Code::from(code), When::Process).to_string();
         return Err(Error::Custom {
-            reason: FinalError::with_title(format!("failed to extract {}", path.display())).detail(inner),
+            reason: FinalError::with_title(format!("failed to extract {}", PathFmt(&path))).detail(inner),
         });
     }
     let _status = cb_result?;

--- a/src/archive/rar.rs
+++ b/src/archive/rar.rs
@@ -1,11 +1,14 @@
 //! Contains RAR-specific building and unpacking functions
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-use unrar::Archive;
+use unrar::{
+    Archive, ExtractEvent,
+    error::{Code, UnrarError, When},
+};
 
 use crate::{
-    error::{Error, Result},
+    error::{Error, FinalError, Result},
     info,
     list::{FileInArchive, ListFileType},
     utils::BytesFmt,
@@ -19,24 +22,49 @@ pub fn unpack_archive(archive_path: &Path, output_folder: &Path, password: Optio
         None => Archive::new(archive_path),
     };
 
-    let mut archive = archive.open_for_processing()?;
-    let mut files_unpacked = 0;
+    let archive = archive.open_for_processing()?;
 
-    while let Some(header) = archive.read_header()? {
-        let entry = header.entry();
-        archive = if entry.is_file() {
-            info!(
-                "extracted ({}) {}",
-                BytesFmt(entry.unpacked_size),
-                entry.filename.display(),
-            );
+    let mut files_unpacked: u64 = 0;
+    let mut first_err: Option<(PathBuf, i32)> = None;
+
+    let cb_result = archive.extract_all_with_callback(output_folder, |event| match event {
+        ExtractEvent::Start { filename, size } => {
+            info!("extracted ({}) {}", BytesFmt(size), filename.display());
+            true
+        }
+        ExtractEvent::Ok { .. } => {
             files_unpacked += 1;
-            header.extract_with_base(output_folder)?
-        } else {
-            header.skip()?
-        };
-    }
+            true
+        }
+        ExtractEvent::Err { filename, error_code } => {
+            first_err = Some((filename, error_code));
+            // Returning false cancels the rest of the extraction so any
+            // additional per-file errors don't get silently swallowed.
+            false
+        }
+        ExtractEvent::LargeDictWarning {
+            dict_size_kb,
+            max_dict_size_kb,
+        } => {
+            info!(
+                "archive requires {} KiB dictionary; this build supports up to {} KiB",
+                dict_size_kb, max_dict_size_kb,
+            );
+            // Reject the oversized dictionary so the DLL fails the
+            // operation with Code::LargeDict instead of silently
+            // proceeding with a result it cannot actually produce.
+            false
+        }
+        _ => true,
+    });
 
+    if let Some((path, code)) = first_err {
+        let inner = UnrarError::from(Code::from(code), When::Process).to_string();
+        return Err(Error::Custom {
+            reason: FinalError::with_title(format!("failed to extract {}", path.display())).detail(inner),
+        });
+    }
+    let _status = cb_result?;
     Ok(files_unpacked)
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -249,7 +249,7 @@ impl From<zip::result::ZipError> for Error {
 impl From<unrar::error::UnrarError> for Error {
     fn from(err: unrar::error::UnrarError) -> Self {
         Self::Custom {
-            reason: FinalError::with_title("Unexpected error in rar archive").detail(format!("{:?}", err.code)),
+            reason: FinalError::with_title("Unexpected error in rar archive").detail(err.to_string()),
         }
     }
 }


### PR DESCRIPTION
resolve https://github.com/ouch-org/ouch/issues/714

perf test:


<details>
<summary>


## RAR Extraction Performance Comparison (Linux kernel v7.0 source)                                                                              

this is test runs on a physical machine
 
tested under `tmpfs` to avoid filesystem I/O impact.
builtin `time` command comes from fish shell

Linux: kernel 7.0.3
shell: fish
rar/unrar:  7.22
unzip:  UnZip 6.00 of 20 April 2009, by Info-ZIP

CPU:  12th Gen Intel(R) Core(TM) i7-12700
RAM:  32GB                                                          
                                                                                           
  Test file: `kernel-v7.0.rar` (created from Linux kernel v7.0 source tree)                                                                        
                                                                                                                                                   
  ### Extraction Performance                                                                                                                       
                                                                                                                                                   
  | Tool | Command | Executed (wall) | User CPU | Sys CPU |                                                                                        
  |------|---------|-----------------|----------|---------|                                                                                      
  | `unrar` (official) | `unrar x kernel-v7.0.rar` | **7.15 s** | 7.07 s | 1.25 s |                                                                
  | `ouch` 0.7.1 (old release) | `ouch decompress kernel-v7.0.rar` | 70.69 s | 68.03 s | 4.71 s |                                                  
  | `ouch` (this PR) | `ouch decompress kernel-v7.0.rar` | **6.88 s** | 6.74 s | 1.35 s |                                                          
                                                                                                                                                   
  ### Reference: Other Formats                                                                                                                     
                                                                                                                                                   
  | Tool | Command | Executed (wall) | User CPU | Sys CPU |                                                                                        
  |------|---------|-----------------|----------|---------|                                                                                      
  | `unzip` | `unzip v7.0.zip` | 7.17 s | 6.20 s | 0.95 s |                                                                                      
  | `rar` (compression) | `rar a -r kernel-v7.0.rar ./linux-7.0/` | 20.12 s | 102.85 s | 10.30 s |                                                 
                                                                                                                                                   
  ### Key Takeaways                                                                                                                                
                                                                                                                                                   
  - **This PR (backed by `unrar-ng` 0.7.6) is ~10.3x faster** than the previous release (70.69 s → 6.88 s).                                        
  - Performance is on par with the official `unrar` tool (6.88 s vs 7.15 s).                                   
  - Comparable to `unzip` extracting the same content (6.88 s vs 7.17 s).       

### Click  here to expand and show detailed test steps below

</summary>

```shell
# ensure /tmp is tmpfs, not disk
❯ mount | grep /tmp
tmpfs on /tmp type tmpfs (rw,nosuid,nodev,size=15858944k,nr_inodes=1048576,inode64,usrquota)

❯ cd /tmp
❯ mkdir perf-test
❯ cd perf-test/
❯ curl -LZO https://github.com/ouch-org/ouch/releases/download/0.7.1/ouch-x86_64-unknown-linux-gnu.tar.gz
❯ curl -LZO https://github.com/torvalds/linux/archive/refs/tags/v7.0.zip

❯ tar xvzf ouch-x86_64-unknown-linux-gnu.tar.gz 

❯ time unzip v7.0.zip
Executed in    7.17 secs    fish           external
   usr time    6.20 secs    0.00 millis    6.20 secs
   sys time    0.95 secs    1.99 millis    0.95 secs


❯ time rar a -r kernel-v7.0.rar ./linux-7.0/
________________________________________________________
Executed in   20.12 secs    fish           external
   usr time  102.85 secs    1.40 millis  102.85 secs
   sys time   10.30 secs    1.78 millis   10.29 secs

❯ rm -rf linux-7.0/

❯ time unrar x kernel-v7.0.rar 
________________________________________________________
Executed in    7.15 secs    fish           external
   usr time    7.07 secs    0.00 millis    7.07 secs
   sys time    1.25 secs    2.73 millis    1.25 secs

❯ rm -rf linux-7.0/

❯ time ./ouch-x86_64-unknown-linux-gnu/ouch decompress -d ouch-extracted  kernel-v7.0.rar 
________________________________________________________
Executed in   70.69 secs    fish           external
   usr time   68.03 secs    1.47 millis   68.03 secs
   sys time    4.71 secs    1.74 millis    4.71 secs

❯ time ~/repo/rust/ouch/target/release/ouch decompress -d ouch-pr-extracted  kernel-v7.0.rar 
________________________________________________________
Executed in    6.88 secs    fish           external
   usr time    6.74 secs    0.19 millis    6.73 secs
   sys time    1.35 secs    3.04 millis    1.35 secs
```

</details>

Migrate RAR decompression from upstream unrar 0.5.7 to the maintained fork unrar-ng 0.7.3 via Cargo dep alias (source-level use unrar::* preserved). Replace the per-file read_header + extract_with_base loop with OpenArchive::extract_all_with_callback, which uses the C batch path internally and avoids per-file FFI overhead -- noticeably faster for archives with many small files.

Behavioral notes:

- Directory entries in the archive are now materialized on disk by the C library; the previous loop explicitly skipped non-file headers so empty directories were not created. Most users expect the archive's original directory layout, so this is treated as a fix.
- Per-file errors are captured in the callback and surfaced as Error::Custom with a "failed to extract <path>" title plus a human-readable detail, rather than relying on a bare From<UnrarError> conversion (which omitted the filename context).
- From<UnrarError> now formats via Display (err.to_string()) instead of the previous Debug-formatted err.code, so messages such as "Wrong password was specified" replace the bare BadPassword enum debug text. Covers LargeDict and the new Unmapped(i32) fallback too.
- Closure handles the new ExtractEvent::LargeDictWarning by emitting an info line with the required vs supported dictionary size, then letting the DLL fail naturally to Err(LargeDict).

<!--
If your code changes text output, you might need to update snapshots
of UI tests, read more about `insta` at CONTRIBUTING.md.

Remember to edit `CHANGELOG.md` after opening the PR.
-->
