### PR TITLE
feat: use sigstore signing

### DIFF
--- a/.github/workflows/draft-release-automatic-trigger.yml
+++ b/.github/workflows/draft-release-automatic-trigger.yml
@@ -16,6 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     needs: call-workflow-build-artifacts-and-run-tests
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,6 +32,11 @@ jobs:
 
       - name: Package release assets
         run: scripts/package-release-assets.sh
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: "output_assets/ouch-*"
 
       - name: Create release
         uses: softprops/action-gh-release@v2

--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ cargo install ouch
 
 Check the [releases page](https://github.com/ouch-org/ouch/releases).
 
+Release binaries are signed with [Sigstore](https://sigstore.dev) via GitHub's artifact attestations. Verify a downloaded binary with the GitHub CLI:
+
+```
+gh attestation verify ouch-x86_64-unknown-linux-musl --repo ouch-org/ouch
+```
+
 ## Compiling from source code
 
 Check the [wiki guide on compiling](https://github.com/ouch-org/ouch/wiki/Compiling-and-installing-from-source-code).


### PR DESCRIPTION
This PR adds automated signature creation using sigstore.

Sigstore is a modern approach to signing source code and binary releases that does not require developers to maintain and secure private signature keys and simplify the signature process. Effectively signatures are done using short lived signing keys bound to the authentication process. Validation is done through a transparency log approach. this means all release signatures are logged in the public transparency log, allowing everyone to verify that the signature was authenticated in github. It will also list all signatures created, so even if the repo were to be compromised, all new signatures would be visible and cannot be hidden.

The advantages:
- no private (pgp) key management
- all users can verify valid releases were authenticated by github (and distro maintainers can verify the release too)
- maintainers can also check the transparency log to verify that all issued releases align with what they released.
- Fully automated on github, zero future work