### PR TITLE
Handle GNUSparse archive entries during tar decompression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Categories Used:
 ### Bug Fixes
 
 - Fix various panics not handled gracefully (https://github.com/ouch-org/ouch/pull/950)
+- Handle GNUSparse archive entries during tar decompression (https://github.com/ouch-org/ouch/pull/975)
 
 ### Tweaks
 

--- a/src/archive/tar.rs
+++ b/src/archive/tar.rs
@@ -57,7 +57,7 @@ pub fn unpack_archive(reader: impl Read, output_folder: &Path) -> Result<u64> {
 
                 fs::hard_link(&full_target_path, &full_link_path)?;
             }
-            tar::EntryType::Regular => {
+            tar::EntryType::Regular | tar::EntryType::GNUSparse => {
                 entry.unpack_in(output_folder)?;
             }
             tar::EntryType::Directory => {


### PR DESCRIPTION
Currently, compressing files into a tar archive via `ouch compress` may create `GNUSparse` archive entries if appropriate, since the tar crate's `Builder` is initialized with the `sparse` option set to `true`. However, during decompression, this entry type is not handled which leads to silently skipped archive entries.
Handling this entry type using `unpack_in` matches the decompression result of GNU tar for sparse archive entries.