### PR TITLE
build: improve man pages for subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ Categories Used:
 ### Improvements
 
 - Report mtime-set errors for `.7z` as warnings (https://github.com/ouch-org/ouch/pull/950)
-
 - Improve man pages for subcommands (https://github.com/ouch-org/ouch/pull/980)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Categories Used:
 
 - Report mtime-set errors for `.7z` as warnings (https://github.com/ouch-org/ouch/pull/950)
 
+- Improve man pages for subcommands (https://github.com/ouch-org/ouch/pull/980)
+
 ### Bug Fixes
 
 - Fix various panics not handled gracefully (https://github.com/ouch-org/ouch/pull/950)

--- a/build.rs
+++ b/build.rs
@@ -11,16 +11,11 @@
 /// All completion files will be generated inside of the folder "man-page-and-completions-artifacts".
 ///
 /// If the folder does not exist, it will be created.
-use std::{
-    env,
-    fs::{File, create_dir_all},
-    path::Path,
-};
+use std::{env, fs::create_dir_all, path::Path};
 
 use clap::{CommandFactory, ValueEnum};
 use clap_complete::{Shell, generate_to};
 use clap_complete_nushell::Nushell;
-use clap_mangen::Man;
 
 include!("src/cli/args.rs");
 
@@ -32,16 +27,7 @@ fn main() {
         create_dir_all(out).unwrap();
         let cmd = &mut CliArgs::command();
 
-        Man::new(cmd.clone())
-            .render(&mut File::create(out.join("ouch.1")).unwrap())
-            .unwrap();
-
-        for subcmd in cmd.get_subcommands() {
-            let name = format!("ouch-{}", subcmd.get_name());
-            Man::new(subcmd.clone().name(&name))
-                .render(&mut File::create(out.join(format!("{name}.1"))).unwrap())
-                .unwrap();
-        }
+        clap_mangen::generate_to(cmd.clone(), out).unwrap();
 
         for shell in Shell::value_variants() {
             generate_to(*shell, cmd, "ouch", out).unwrap();


### PR DESCRIPTION
<!--
If your code changes text output, you might need to update snapshots
of UI tests, read more about `insta` at CONTRIBUTING.md.

Remember to edit `CHANGELOG.md` after opening the PR.
-->

https://github.com/clap-rs/clap/pull/5331 added [`clap_mangen::generate_to`](https://docs.rs/clap_mangen/latest/clap_mangen/fn.generate_to.html), which automatically generates man pages for subcommands as well

this makes the generated man pages for subcommands a little nicer, showing `ouch compress` instead of `ouch-compress`