### PR TITLE
dependabot improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
       - "dependencies"
     commit-message:
       prefix: "deps"
+    cooldown:
+      default-days: 7
     groups:
       # Patch and minor bumps land together to reduce PR churn.
       # Major bumps still get one PR each so they get a proper review.
@@ -31,6 +33,8 @@ updates:
       - "ci"
     commit-message:
       prefix: "ci"
+    cooldown:
+      default-days: 7
     groups:
       # We are less likely to be affected by breaking changes in GitHub Actions
       # So Major bumps are accepted to reduce the amount of pull requests

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,7 +32,7 @@ updates:
     commit-message:
       prefix: "ci"
     groups:
-      gha-patch-and-minor:
-        update-types:
-          - "patch"
-          - "minor"
+      # We are less likely to be affected by breaking changes in GitHub Actions
+      # So Major bumps are accepted to reduce the amount of pull requests
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
- enable cooldowns to reduce the risk of supply chain attacks, since it's not reasonable to audit every dependabot update
- group all github actions updates, since we are less likely to be affected by their breaking changes