### PR TITLE
Add Appimage release

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,4 @@
 <!--
 If your code changes text output, you might need to update snapshots
 of UI tests, read more about `insta` at CONTRIBUTING.md.
-
-Remember to edit `CHANGELOG.md` after opening the PR.
 -->

--- a/.github/workflows/draft-release-automatic-trigger.yml
+++ b/.github/workflows/draft-release-automatic-trigger.yml
@@ -30,6 +30,9 @@ jobs:
           path: downloaded_artifacts
           pattern: ouch-*
 
+      - name: Install AppImage dependencies
+        run: sudo apt-get update && sudo apt-get install -y desktop-file-utils
+
       - name: Package release assets
         run: scripts/package-release-assets.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,6 @@ Categories Used:
 - List: show symlink targets (for tar and zip) (https://github.com/ouch-org/ouch/pull/934)
 - Add aliases for ebooks (`.epub`) (https://github.com/ouch-org/ouch/pull/981)
 - Add a Landlock sandbox on Linux for `compress`/`decompress`/`list` that restricts filesystem access and, where the kernel supports it, blocks new TCP connections, abstract-socket use, and signals to processes outside the sandbox (disable with `--no-sandbox` or the `OUCH_NO_SANDBOX` environment variable) (https://github.com/ouch-org/ouch/pull/995)
-- Add appimage binary to releases (https://github.com/ouch-org/ouch/pull/992)
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Categories Used:
 - List: show symlink targets (for tar and zip) (https://github.com/ouch-org/ouch/pull/934)
 - Add aliases for ebooks (`.epub`) (https://github.com/ouch-org/ouch/pull/981)
 - Add a Landlock sandbox on Linux for `compress`/`decompress`/`list` that restricts filesystem access and, where the kernel supports it, blocks new TCP connections, abstract-socket use, and signals to processes outside the sandbox (disable with `--no-sandbox` or the `OUCH_NO_SANDBOX` environment variable) (https://github.com/ouch-org/ouch/pull/995)
+- Add appimage binary to releases (https://github.com/ouch-org/ouch/pull/992)
 
 ### Improvements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,9 +23,6 @@ Before opening the PR, open an issue to discuss your addition, this increases th
 ## PRs
 
 - Pass all CI checks.
-- After opening the PR, add a [CHANGELOG.md] entry.
-
-[CHANGELOG.md]: https://github.com/ouch-org/ouch
 
 ### CI Tests
 

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -e
+
+# Builds a single-file AppImage from a compiled ouch binary.
+# Usage: build-appimage.sh <binary> <arch:x86_64|aarch64> <output>
+
+BINARY="$1"
+APPIMAGE_ARCH="$2"
+OUTPUT="$3"
+
+if [ -z "$BINARY" ] || [ -z "$APPIMAGE_ARCH" ] || [ -z "$OUTPUT" ]; then
+    echo "usage: build-appimage.sh <binary> <arch> <output>" >&2
+    exit 1
+fi
+
+case "$APPIMAGE_ARCH" in
+    x86_64 | aarch64) ;;
+    *)
+        echo "unsupported AppImage arch: $APPIMAGE_ARCH" >&2
+        exit 1
+        ;;
+esac
+
+APPIMAGETOOL_VERSION="1.9.0"
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+APPDIR="$WORKDIR/ouch.AppDir"
+mkdir -p "$APPDIR/usr/bin"
+
+cp "$BINARY" "$APPDIR/usr/bin/ouch"
+chmod +x "$APPDIR/usr/bin/ouch"
+
+cat > "$APPDIR/ouch.desktop" <<'EOF'
+[Desktop Entry]
+Type=Application
+Name=ouch
+Comment=A command-line utility for easily compressing and decompressing files and directories
+Exec=ouch
+Icon=ouch
+Categories=Utility;
+Terminal=true
+EOF
+
+# dummy 1x1 transparent PNG
+base64 -d > "$APPDIR/ouch.png" <<'EOF'
+iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGNgAAIAAAUAAeImBZsAAAAASUVORK5CYII=
+EOF
+ln -s ouch.png "$APPDIR/.DirIcon"
+
+cat > "$APPDIR/AppRun" <<'EOF'
+#!/bin/sh
+HERE="$(dirname "$(readlink -f "$0")")"
+exec "$HERE/usr/bin/ouch" "$@"
+EOF
+chmod +x "$APPDIR/AppRun"
+
+APPIMAGETOOL="$WORKDIR/appimagetool"
+wget -q -O "$APPIMAGETOOL" \
+    "https://github.com/AppImage/appimagetool/releases/download/${APPIMAGETOOL_VERSION}/appimagetool-x86_64.AppImage"
+chmod +x "$APPIMAGETOOL"
+
+RUNTIME="$WORKDIR/runtime-$APPIMAGE_ARCH"
+wget -q -O "$RUNTIME" \
+    "https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-$APPIMAGE_ARCH"
+
+# extract-and-run: no FUSE in CI. SOURCE_DATE_EPOCH: reproducible squashfs.
+ARCH="$APPIMAGE_ARCH" APPIMAGE_EXTRACT_AND_RUN=1 "$APPIMAGETOOL" \
+    --no-appstream \
+    --runtime-file "$RUNTIME" \
+    "$APPDIR" "$OUTPUT"
+
+echo "Created $OUTPUT"

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -56,17 +56,28 @@ exec "$HERE/usr/bin/ouch" "$@"
 EOF
 chmod +x "$APPDIR/AppRun"
 
+# appimagetool runs on the build host, so download it for the host arch
+case "$(uname -m)" in
+    x86_64) TOOL_ARCH="x86_64" ;;
+    aarch64 | arm64) TOOL_ARCH="aarch64" ;;
+    *)
+        echo "unsupported host arch for appimagetool: $(uname -m)" >&2
+        exit 1
+        ;;
+esac
+
 APPIMAGETOOL="$WORKDIR/appimagetool"
 wget -q -O "$APPIMAGETOOL" \
-    "https://github.com/AppImage/appimagetool/releases/download/${APPIMAGETOOL_VERSION}/appimagetool-x86_64.AppImage"
+    "https://github.com/AppImage/appimagetool/releases/download/${APPIMAGETOOL_VERSION}/appimagetool-${TOOL_ARCH}.AppImage"
 chmod +x "$APPIMAGETOOL"
 
 RUNTIME="$WORKDIR/runtime-$APPIMAGE_ARCH"
 wget -q -O "$RUNTIME" \
     "https://github.com/AppImage/type2-runtime/releases/download/continuous/runtime-$APPIMAGE_ARCH"
 
-# extract-and-run: no FUSE in CI. SOURCE_DATE_EPOCH: reproducible squashfs.
-ARCH="$APPIMAGE_ARCH" APPIMAGE_EXTRACT_AND_RUN=1 "$APPIMAGETOOL" \
+# no FUSE needed in CI; unset SOURCE_DATE_EPOCH or mksquashfs aborts (appimagetool sets its own timestamp)
+env -u SOURCE_DATE_EPOCH \
+    ARCH="$APPIMAGE_ARCH" APPIMAGE_EXTRACT_AND_RUN=1 "$APPIMAGETOOL" \
     --no-appstream \
     --runtime-file "$RUNTIME" \
     "$APPDIR" "$OUTPUT"

--- a/scripts/package-release-assets.sh
+++ b/scripts/package-release-assets.sh
@@ -65,12 +65,13 @@ for platform in "${PLATFORMS[@]}"; do
         rm -rf "$path/target"
         chmod +x "$path/ouch"
 
-        # Portable single-file AppImage for the glibc Linux targets.
+        # Portable single-file AppImage from the static musl binaries
+        # (zero shared-library dependencies, runs on any Linux).
         case "$platform" in
-            x86_64-unknown-linux-gnu)
+            x86_64-unknown-linux-musl)
                 ../scripts/build-appimage.sh "$path/ouch" x86_64 "../output_assets/${path}.AppImage"
                 ;;
-            aarch64-unknown-linux-gnu)
+            aarch64-unknown-linux-musl)
                 ../scripts/build-appimage.sh "$path/ouch" aarch64 "../output_assets/${path}.AppImage"
                 ;;
         esac

--- a/scripts/package-release-assets.sh
+++ b/scripts/package-release-assets.sh
@@ -65,6 +65,16 @@ for platform in "${PLATFORMS[@]}"; do
         rm -rf "$path/target"
         chmod +x "$path/ouch"
 
+        # Portable single-file AppImage for the glibc Linux targets.
+        case "$platform" in
+            x86_64-unknown-linux-gnu)
+                ../scripts/build-appimage.sh "$path/ouch" x86_64 "../output_assets/${path}.AppImage"
+                ;;
+            aarch64-unknown-linux-gnu)
+                ../scripts/build-appimage.sh "$path/ouch" aarch64 "../output_assets/${path}.AppImage"
+                ;;
+        esac
+
         # --sort=name pins file order, --owner/--group/--numeric-owner pin uids,
         # --mtime pins timestamps. piping through gzip -n drops the gzip header
         # timestamp and original-name field.


### PR DESCRIPTION
This adds the creation of an appimage build to the release

Uses musl libc to avoid dependency to glibc