### PR TITLE
Add archive dir decompress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Categories Used:
 
 ### New Features
 
+- Add `--archive-dir` / `-a` option to decompress archives into a directory named after the archive.
+
 ### Improvements
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ The `-d/--dir` flag can be used to redirect decompression results to another dir
 ```sh
 # Decompress 'summer_vacation.zip' inside of new folder 'pictures'
 ouch decompress summer_vacation.zip --dir pictures
+
+# Create 'summer_vacation/' next to the archive and decompress there
+ouch decompress summer_vacation.zip -a
+
+# Create 'pictures/summer_vacation/' and decompress there
+ouch decompress summer_vacation.zip -a --dir pictures
 ```
 
 ## Compressing

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -102,6 +102,10 @@ pub enum Subcommand {
         #[arg(long = "here")]
         here: bool,
 
+        /// Extract each archive into a directory named after the archive
+        #[arg(short = 'a', long = "archive-dir", conflicts_with = "here")]
+        archive_dir: bool,
+
         /// Remove the source file after successful decompression
         #[arg(short = 'r', long)]
         remove: bool,
@@ -161,6 +165,7 @@ mod tests {
                 files: vec!["\x00\x11\x22".into()],
                 output_dir: None,
                 here: false,
+                archive_dir: false,
                 remove: false,
             },
         }
@@ -175,6 +180,7 @@ mod tests {
                     files: to_paths(["file.tar.gz"]),
                     output_dir: None,
                     here: false,
+                    archive_dir: false,
                     remove: false,
                 },
                 ..mock_cli_args()
@@ -187,6 +193,7 @@ mod tests {
                     files: to_paths(["file.tar.gz"]),
                     output_dir: None,
                     here: false,
+                    archive_dir: false,
                     remove: false,
                 },
                 ..mock_cli_args()
@@ -199,6 +206,33 @@ mod tests {
                     files: to_paths(["a", "b", "c"]),
                     output_dir: None,
                     here: false,
+                    archive_dir: false,
+                    remove: false,
+                },
+                ..mock_cli_args()
+            }
+        );
+        test!(
+            "ouch d file.tar.gz -a",
+            CliArgs {
+                cmd: Subcommand::Decompress {
+                    files: to_paths(["file.tar.gz"]),
+                    output_dir: None,
+                    here: false,
+                    archive_dir: true,
+                    remove: false,
+                },
+                ..mock_cli_args()
+            }
+        );
+        test!(
+            "ouch d file.tar.gz -a --dir out",
+            CliArgs {
+                cmd: Subcommand::Decompress {
+                    files: to_paths(["file.tar.gz"]),
+                    output_dir: Some(PathBuf::from("out")),
+                    here: false,
+                    archive_dir: true,
                     remove: false,
                 },
                 ..mock_cli_args()

--- a/src/commands/decompress.rs
+++ b/src/commands/decompress.rs
@@ -36,6 +36,9 @@ pub struct DecompressOptions<'a> {
     /// `--here`: extract directly into the current directory like `tar -xf`.
     /// Only meaningful when `output_dir_was_explicit` is false.
     pub here: bool,
+    /// `--archive-dir`: extract archives into a basename-derived subdirectory,
+    /// either next to the archive or inside the explicit output directory.
+    pub archive_dir: bool,
     pub question_policy: QuestionPolicy,
     pub password: Option<&'a [u8]>,
     pub remove: bool,
@@ -94,12 +97,13 @@ pub fn decompress_file(options: DecompressOptions) -> Result<()> {
     };
 
     // Decide where archives extract:
-    //   --dir <X>     -> extract into <X>, no wrapper, no flatten
-    //   --here        -> extract into CWD (output_dir), no wrapper
-    //   default       -> extract into a basename-derived subdirectory; flatten the
-    //                    duplicate when the wrapper would contain exactly one entry
-    //                    whose name equals the basename
-    let archive_output_dir: &Path = if options.output_dir_was_explicit || options.here {
+    //   --dir <X>             -> extract into <X>, no wrapper, no flatten
+    //   --here                -> extract into CWD (output_dir), no wrapper
+    //   --archive-dir [-d X]  -> extract into a basename-derived subdirectory
+    //   default               -> extract into a basename-derived subdirectory; flatten the
+    //                            duplicate when the wrapper would contain exactly one entry
+    //                            whose name equals the basename
+    let archive_output_dir: &Path = if options.here || (options.output_dir_was_explicit && !options.archive_dir) {
         options.output_dir
     } else {
         &options.output_file_path
@@ -206,11 +210,11 @@ pub fn decompress_file(options: DecompressOptions) -> Result<()> {
             files_unpacked,
             output_path,
         } => {
-            // In default mode (no --dir, no --here), if the wrapper subdir we created
-            // ended up containing exactly one entry whose name matches the wrapper itself
+            // In wrapper-directory modes, if the wrapper subdir we created ended up
+            // containing exactly one entry whose name matches the wrapper itself
             // (e.g. `archive.zip` contained a single `archive/` root), flatten that
             // duplicate so the user sees `./archive/...` not `./archive/archive/...`.
-            if !options.output_dir_was_explicit && !options.here {
+            if !options.here && (!options.output_dir_was_explicit || options.archive_dir) {
                 deduplicate_basename_wrapper(&output_path)?;
             }
             info_accessible!("Successfully decompressed archive to {}", PathFmt(&output_path));

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -142,6 +142,7 @@ pub fn run(args: CliArgs, question_policy: QuestionPolicy, file_visibility_polic
             files,
             output_dir,
             here,
+            archive_dir,
             remove,
         } => {
             let mut files_output_paths: Vec<_> = vec![];
@@ -197,11 +198,19 @@ pub fn run(args: CliArgs, question_policy: QuestionPolicy, file_visibility_polic
                 .zip(files_extensions)
                 .zip(files_output_paths)
                 .try_for_each(|((input_path, formats), file_name)| {
+                    let is_archive = formats.first().is_some_and(|format| format.is_archive());
+                    let output_base_dir =
+                        if output_dir_was_explicit || !archive_dir || !is_archive || is_path_stdin(input_path) {
+                            &output_dir
+                        } else {
+                            input_path.parent().unwrap_or(&output_dir)
+                        };
+
                     // Path used by single file format archives
                     let output_file_path = if is_path_stdin(&file_name) {
-                        output_dir.join("ouch-output")
+                        output_base_dir.join("ouch-output")
                     } else {
-                        output_dir.join(file_name)
+                        output_base_dir.join(file_name)
                     };
 
                     decompress_file(DecompressOptions {
@@ -211,6 +220,7 @@ pub fn run(args: CliArgs, question_policy: QuestionPolicy, file_visibility_polic
                         output_file_path,
                         output_dir_was_explicit,
                         here,
+                        archive_dir,
                         question_policy,
                         password: args.password.as_deref().map(|str| {
                             <[u8] as ByteSlice>::from_os_str(str).expect("convert password to bytes failed")

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -229,6 +229,87 @@ fn multiple_files(
     assert_same_directory(before, after, !matches!(ext, DirectoryExtension::Zip));
 }
 
+#[test]
+fn archive_dir_extracts_next_to_archive_when_output_dir_is_omitted() {
+    let (_tempdir, dir) = testdir().unwrap();
+    let before = dir.join("before");
+    let input = before.join("payload");
+    let archive_dir = dir.join("archives");
+    let archive = archive_dir.join("bundle.tar");
+    let expected = archive_dir.join("bundle");
+
+    fs::create_dir_all(&input).unwrap();
+    fs::create_dir_all(&archive_dir).unwrap();
+    fs::write(input.join("file.txt"), "hello").unwrap();
+
+    ouch!("-A", "c", &input, &archive);
+    crate::utils::cargo_bin()
+        .arg("-A")
+        .arg("decompress")
+        .arg(&archive)
+        .arg("-a")
+        .current_dir(&dir)
+        .assert()
+        .success();
+
+    assert!(!dir.join("bundle").exists());
+    assert_same_directory(&before, &expected, false);
+}
+
+#[test]
+fn archive_dir_extracts_inside_named_folder_under_output_dir() {
+    let (_tempdir, dir) = testdir().unwrap();
+    let before = dir.join("before");
+    let input = before.join("payload");
+    let archive = dir.join("bundle.tar");
+    let output = dir.join("output");
+    let expected = output.join("bundle");
+
+    fs::create_dir_all(&input).unwrap();
+    fs::write(input.join("file.txt"), "hello").unwrap();
+
+    ouch!("-A", "c", &input, &archive);
+    crate::utils::cargo_bin()
+        .arg("-A")
+        .arg("decompress")
+        .arg(&archive)
+        .arg("--archive-dir")
+        .arg("--dir")
+        .arg(&output)
+        .assert()
+        .success();
+
+    assert_same_directory(&before, &expected, false);
+}
+
+#[test]
+fn archive_dir_does_not_move_single_file_output_next_to_input() {
+    let (_tempdir, dir) = testdir().unwrap();
+    let before = dir.join("before");
+    let input = before.join("file");
+    let archive_dir = dir.join("archives");
+    let archive = archive_dir.join("file.gz");
+    let cwd = dir.join("cwd");
+
+    fs::create_dir_all(&before).unwrap();
+    fs::create_dir_all(&archive_dir).unwrap();
+    fs::create_dir_all(&cwd).unwrap();
+    fs::write(&input, "hello").unwrap();
+
+    ouch!("-A", "c", &input, &archive);
+    crate::utils::cargo_bin()
+        .arg("-A")
+        .arg("decompress")
+        .arg(&archive)
+        .arg("-a")
+        .current_dir(&cwd)
+        .assert()
+        .success();
+
+    assert_eq!(fs::read_to_string(cwd.join("file")).unwrap(), "hello");
+    assert!(!archive_dir.join("file").exists());
+}
+
 #[proptest(cases = 25)]
 fn multiple_files_with_conflict_and_choice_to_overwrite(
     ext: DirectoryExtension,


### PR DESCRIPTION
## Summary

Adds a new `--archive-dir` / `-a` option for `ouch decompress`.

When decompressing an archive without `--dir`, this extracts the archive next to the input archive into a basename-derived directory. When combined with `--dir`, it extracts into a basename-derived directory under the chosen output directory.

## Examples

```sh
ouch decompress summer_vacation.zip -a
ouch decompress summer_vacation.zip -a --dir pictures
