### PR TITLE
fix zip compression

### DIFF
--- a/src/archive/zip.rs
+++ b/src/archive/zip.rs
@@ -260,7 +260,8 @@ where
                     io::copy(&mut file, &mut writer)?;
                 }
                 FileType::Directory => {
-                    writer.add_directory(entry_name, default_options)?;
+                    // Directory entries have no data and get an invalid size when ZIP64 is forced on
+                    writer.add_directory(entry_name, default_options.large_file(false))?;
                 }
                 FileType::Symlink => {
                     let target_path = path.read_link()?;


### PR DESCRIPTION
ouch writes zip files whose folder entries have an invalid size, so strict readers like 7-Zip refuse to open the archive. This started with the recent zip crate update from version 6 to 8, which no longer sets the size correctly on empty folder entries when ZIP64 is enabled. Any zip that contains a folder is affected while single files are fine.