### PR TITLE
Bump package version to 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,7 +1135,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "ouch"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ouch"
-version = "0.8.0"
+version = "0.8.1"
 authors = [
     "João Marcos <marcospb19@hotmail.com>",
     "Vinícius Rodrigues Miguel <vrmiguel99@gmail.com>",


### PR DESCRIPTION
Bumps the Cargo package metadata to 0.8.1 so `ouch --version` matches the 0.8.1 release/tag.

This unblocks Homebrew/homebrew-core#291273, where the formula test currently sees `ouch 0.8.0` from the 0.8.1 source archive.
