### PR TITLE
fix ZIP timestamps across time zones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,6 +1122,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1767,7 +1776,9 @@ checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "js-sys",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ snap = "1.1.1"
 strum = { version = "0.28.0", features = ["derive"] }
 tar = "0.4.46"
 tempfile = "3.27.0"
-time = { version = "0.3.47", default-features = false }
+time = { version = "0.3.47", default-features = false, features = ["local-offset"] }
 unrar = { package = "unrar-ng", version = "0.7.6", optional = true }
 zip = { version = "8.6.0", default-features = false, features = [
     "time",

--- a/src/archive/zip.rs
+++ b/src/archive/zip.rs
@@ -11,7 +11,7 @@ use filetime_creation::{FileTime, set_file_mtime};
 use fs_err as fs;
 use is_executable::is_executable;
 use same_file::Handle;
-use time::{OffsetDateTime, PrimitiveDateTime};
+use time::{OffsetDateTime, PrimitiveDateTime, UtcOffset};
 use zip::{self, DateTime, ZipArchive, read::ZipFile};
 
 #[cfg(unix)]
@@ -325,29 +325,50 @@ fn get_last_modified_time(file: &fs::File) -> DateTime {
         .and_then(|metadata| metadata.modified())
         .ok()
         .and_then(|time| {
-            // zip stores timezone-naive DOS times, so drop the tz from OffsetDateTime
-            let odt = OffsetDateTime::from(time);
-            DateTime::try_from(PrimitiveDateTime::new(odt.date(), odt.time())).ok()
+            let datetime = OffsetDateTime::from(time);
+            let offset = UtcOffset::local_offset_at(datetime).unwrap_or(UtcOffset::UTC);
+            zip_datetime_from_offset(datetime, offset)
         })
         .unwrap_or_default()
 }
 
 fn set_last_modified_time<R: Read>(zip_file: &ZipFile<'_, R>, path: &Path) -> Result<()> {
-    // Extract modification time from zip file and convert to FileTime
     let file_time = zip_file
         .last_modified()
         .and_then(|datetime| PrimitiveDateTime::try_from(datetime).ok())
         .map(|pdt| {
-            // Zip does not support nanoseconds, so we can assume zero here
-            FileTime::from_unix_time(pdt.assume_utc().unix_timestamp(), 0)
+            let offset = local_offset_for(pdt).unwrap_or(UtcOffset::UTC);
+            file_time_from_local_datetime(pdt, offset)
         });
 
-    // Set the modification time if available
     if let Some(modification_time) = file_time {
         set_file_mtime(path, modification_time)?;
     }
 
     Ok(())
+}
+
+fn zip_datetime_from_offset(datetime: OffsetDateTime, offset: UtcOffset) -> Option<DateTime> {
+    let local = datetime.to_offset(offset);
+    DateTime::try_from(PrimitiveDateTime::new(local.date(), local.time())).ok()
+}
+
+fn local_offset_for(datetime: PrimitiveDateTime) -> Option<UtcOffset> {
+    let mut offset = UtcOffset::local_offset_at(datetime.assume_utc()).ok()?;
+
+    for _ in 0..2 {
+        let next = UtcOffset::local_offset_at(datetime.assume_offset(offset)).ok()?;
+        if next == offset {
+            break;
+        }
+        offset = next;
+    }
+
+    Some(offset)
+}
+
+fn file_time_from_local_datetime(datetime: PrimitiveDateTime, offset: UtcOffset) -> FileTime {
+    FileTime::from_unix_time(datetime.assume_offset(offset).unix_timestamp(), 0)
 }
 
 /// A zip mode without Unix file-type bits isn't a real Unix mode, so its permissions are ignored.
@@ -372,5 +393,41 @@ fn zip_non_utf8_error<'a>(path: &'a Path) -> impl Fn() -> FinalError + 'a {
     || {
         FinalError::with_title("Zip requires that all paths are valid UTF-8")
             .detail(format!("File {} has a non-UTF-8 path", PathFmt(path)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use time::{Date, Month, Time};
+
+    use super::*;
+
+    #[test]
+    fn zip_timestamps_round_trip_with_offset() {
+        let date = Date::from_calendar_date(2026, Month::February, 7).unwrap();
+        let local = PrimitiveDateTime::new(date, Time::from_hms(10, 6, 50).unwrap());
+        let offset = UtcOffset::from_hms(-6, 0, 0).unwrap();
+        let instant = local.assume_offset(offset);
+
+        let datetime = zip_datetime_from_offset(instant, offset).unwrap();
+        assert_eq!(PrimitiveDateTime::try_from(datetime).unwrap(), local);
+
+        let file_time = file_time_from_local_datetime(local, offset);
+        assert_eq!(file_time.unix_seconds(), instant.unix_timestamp());
+    }
+
+    #[test]
+    fn zip_timestamps_round_trip_with_local_offset() {
+        let instant = Date::from_calendar_date(2026, Month::February, 7)
+            .unwrap()
+            .with_hms(12, 34, 56)
+            .unwrap()
+            .assume_utc();
+        let offset = UtcOffset::local_offset_at(instant).unwrap();
+        let datetime = zip_datetime_from_offset(instant, offset).unwrap();
+        let local = PrimitiveDateTime::try_from(datetime).unwrap();
+        let resolved_offset = local_offset_for(local).unwrap();
+        let file_time = file_time_from_local_datetime(local, resolved_offset);
+        assert_eq!(file_time.unix_seconds(), instant.unix_timestamp());
     }
 }


### PR DESCRIPTION
Fixes #902.

ZIP stores modification times as timezone-naive local clock values. Ouch previously treated those values as UTC during extraction and wrote UTC clock values when creating archives, shifting file times by the local UTC offset.

Archive creation now converts filesystem timestamps to the applicable local offset before writing the ZIP timestamp. Extraction resolves the local offset for the stored date and converts that clock value back to the corresponding filesystem timestamp, including historical daylight-saving offsets.

Tests cover a fixed non-UTC offset and the host's actual local offset.

Validation:

- `cargo test --no-default-features --features unrar,use_zlib,use_zstd_thin` (103 passed)
- `rustfmt --edition 2024 --check --config newline_style=Native src/archive/zip.rs`
- `cargo clippy --bin ouch --no-default-features --features unrar,use_zlib,use_zstd_thin`
