### PR TITLE
fix(compress): a negative --level gave maximum compression

### DIFF
--- a/src/commands/compress.rs
+++ b/src/commands/compress.rs
@@ -54,7 +54,7 @@ pub fn compress_files(
                 // instead of the regular default that flate2 uses
                 let parz: ParCompress<gzp::deflate::Gzip, _> = ParCompressBuilder::new()
                     .compression_level(
-                        level.map_or_else(Default::default, |l| gzp::Compression::new((l as u32).clamp(0, 9))),
+                        level.map_or_else(Default::default, |l| gzp::Compression::new(l.clamp(0, 9) as u32)),
                     )
                     .num_threads(logical_thread_count())
                     .expect("gpz: num_threads must be greater than 0")
@@ -63,7 +63,7 @@ pub fn compress_files(
             }),
             Bzip => Box::new(bzip2::write::BzEncoder::new(
                 encoder,
-                level.map_or_else(Default::default, |l| bzip2::Compression::new((l as u32).clamp(1, 9))),
+                level.map_or_else(Default::default, |l| bzip2::Compression::new(l.clamp(1, 9) as u32)),
             )),
             Bzip3 => {
                 #[cfg(not(feature = "bzip3"))]
@@ -78,14 +78,14 @@ pub fn compress_files(
             Lz4 => Box::new(lz4_flex::frame::FrameEncoder::new(encoder).auto_finish()),
             Lzma => {
                 let options = level.map_or_else(Default::default, |l| {
-                    lzma_rust2::LzmaOptions::with_preset((l as u32).clamp(0, 9))
+                    lzma_rust2::LzmaOptions::with_preset(l.clamp(0, 9) as u32)
                 });
                 let writer = lzma_rust2::LzmaWriter::new_use_header(encoder, &options, None)?;
                 Box::new(writer.auto_finish())
             }
             Xz => {
                 let mut options = level.map_or_else(Default::default, |l| {
-                    lzma_rust2::XzOptions::with_preset((l as u32).clamp(0, 9))
+                    lzma_rust2::XzOptions::with_preset(l.clamp(0, 9) as u32)
                 });
                 let dict_size = options.lzma_options.dict_size as u64;
                 options.set_block_size(NonZeroU64::new(dict_size));
@@ -95,7 +95,7 @@ pub fn compress_files(
             }
             Lzip => {
                 let options = level.map_or_else(Default::default, |l| {
-                    lzma_rust2::LzipOptions::with_preset((l as u32).clamp(0, 9))
+                    lzma_rust2::LzipOptions::with_preset(l.clamp(0, 9) as u32)
                 });
                 let writer = lzma_rust2::LzipWriter::new(encoder, options);
                 Box::new(writer.auto_finish())
@@ -103,7 +103,7 @@ pub fn compress_files(
             Snappy => Box::new({
                 let parz: ParCompress<gzp::snap::Snap, _> = ParCompressBuilder::new()
                     .compression_level(gzp::par::compress::Compression::new(
-                        level.map_or_else(Default::default, |l| (l as u32).clamp(0, 9)),
+                        level.map_or_else(Default::default, |l| l.clamp(0, 9) as u32),
                     ))
                     .num_threads(logical_thread_count())
                     .expect("gpz: num_threads must be greater than 0")

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -167,6 +167,33 @@ fn single_file(
     assert_same_directory(before, after, false);
 }
 
+/// A negative `--level` must clamp to the minimum compression, not the maximum.
+///
+/// Regression test: the level was cast to an unsigned integer before clamping, so
+/// `-1i16 as u32` became 4294967295 and `clamp(0, 9)` returned 9, silently giving
+/// maximum compression instead of minimum.
+#[test]
+fn negative_compression_level_is_not_maximum() {
+    let (_tempdir, dir) = testdir().unwrap();
+    let before_file = &dir.join("file");
+    // Highly compressible content, so the compression level actually changes the output size
+    fs::write(before_file, "ouch".repeat(64 * 1024)).unwrap();
+
+    let compress_with_level = |level: &str, name: &str| {
+        let archive = &dir.join(name);
+        ouch!("-A", "c", format!("--level={level}"), before_file, archive);
+        fs::metadata(archive).unwrap().len()
+    };
+
+    let negative = compress_with_level("-1", "negative.gz");
+    let maximum = compress_with_level("9", "maximum.gz");
+
+    assert_ne!(
+        negative, maximum,
+        "--level=-1 must not produce the same output as --level=9 (maximum compression)"
+    );
+}
+
 /// Compress and decompress a single file over stdin.
 #[proptest(cases = 200)]
 fn single_file_stdin(


### PR DESCRIPTION
## What's broken

A negative `--level` silently gives maximum compression, which is the opposite of what was asked for.

```
$ ouch compress big.txt o.gz --level=0  -y ; stat -c%s o.gz
1012168
$ ouch compress big.txt o.gz --level=9  -y ; stat -c%s o.gz
3473
$ ouch compress big.txt o.gz --level=-1 -y ; stat -c%s o.gz
3473          <- asked for below-minimum, got the maximum
$ ouch compress big.txt o.gz --level=-32768 -y ; stat -c%s o.gz
3473
```

## The fix

`level` is an `Option<i16>`, and it was cast before being clamped:

```rust
gzp::Compression::new((l as u32).clamp(0, 9))
```

`-1i16 as u32` is `4294967295`, so `clamp(0, 9)` returns `9`. Clamping first and casting after gives the intended result:

```rust
gzp::Compression::new(l.clamp(0, 9) as u32)
```

Brotli in the same match already does exactly this, `level.unwrap_or(default_level).clamp(0, 11) as u32`, which is what the other arms were meant to look like.

Six arms changed: Gzip, Bzip, Lzma, Xz, Lzip and Snappy.

**Zstd is deliberately untouched.** It casts to `i32`, which preserves the sign for an `i16`, then clamps against `min_c_level()` and `max_c_level()`. Negative zstd levels are a real feature and still work:

```
$ ouch compress big.txt o.zst --level=-1 -y   # still a genuine negative level
```

Bzip3, Lz4 and the container formats ignore `level` entirely.

After:

| level | before | after |
|---|---|---|
| 0 | 1012168 | 1012168 |
| 9 | 3473 | 3473 |
| -1 | 3473 | 1012168 |
| -32768 | 3473 | 1012168 |

## Verification

`negative_compression_level_is_not_maximum` in `tests/integration.rs` asserts `--level=-1` and `--level=9` do not produce the same output. With the change reverted it fails with both sizes equal.

The reason the existing coverage missed this: the `single_file` proptest right above it already drives `-l`, but its strategy is `0i16..12`, so it never generates a negative.

`cargo test` passes, no snapshot changed and none was regenerated, and `cargo fmt -- --check` and `cargo clippy --all-targets` are clean.
