### PR TITLE
fix: bz3 is missing from SUPPORTED_EXTENSIONS

### DIFF
--- a/src/extension.rs
+++ b/src/extension.rs
@@ -16,6 +16,7 @@ pub const SUPPORTED_EXTENSIONS: &[&str] = &[
     "zip",
     "bz",
     "bz2",
+    "bz3",
     "gz",
     "lz4",
     "xz",
@@ -404,6 +405,40 @@ mod tests {
             build_archive_file_suggestion(Path::new("linux.pkg.info.zst"), ".tar").unwrap(),
             "linux.pkg.info.tar.zst"
         );
+    }
+
+    /// `bz3` is a supported extension, so the suggestion must insert `.tar` *before* it.
+    /// Regression: `bz3` was missing from `SUPPORTED_EXTENSIONS`, so the walk skipped it and
+    /// suggested `linux.bz3.tar.gz`, which `ouch` then rejects for a misplaced archive format.
+    #[test]
+    fn builds_suggestion_for_bzip3_extension() {
+        assert_eq!(
+            build_archive_file_suggestion(Path::new("linux.bz3"), ".tar").as_deref(),
+            Some("linux.tar.bz3")
+        );
+        assert_eq!(
+            build_archive_file_suggestion(Path::new("linux.bz3.gz"), ".tar").as_deref(),
+            Some("linux.tar.bz3.gz")
+        );
+    }
+
+    /// Every non-archive extension that `slice_to_extension` accepts must be listed in
+    /// `SUPPORTED_EXTENSIONS`, otherwise the suggestion walk skips it and proposes a path
+    /// `ouch` itself rejects. This is what let `bz3` go missing.
+    /// Archive-first aliases such as `tgz` and `tbz3` live in `SUPPORTED_ALIASES` instead.
+    #[test]
+    fn every_standalone_parsable_extension_is_supported() {
+        for ext in PRETTY_SUPPORTED_EXTENSIONS.split(", ") {
+            let parsed =
+                slice_to_extension(ext.as_bytes()).unwrap_or_else(|| panic!("'{ext}' is advertised but not parsable"));
+            if parsed.compression_formats == [CompressionFormat::Tar] {
+                continue;
+            }
+            assert!(
+                SUPPORTED_EXTENSIONS.contains(&ext),
+                "'{ext}' is advertised and parsable but missing from SUPPORTED_EXTENSIONS"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What's broken

`bz3` is missing from `SUPPORTED_EXTENSIONS`, although `slice_to_extension` parses it and `PRETTY_SUPPORTED_EXTENSIONS` advertises it. The "insert an archive format" hint walks that list, so it does not see the `bz3` boundary and suggests a path ouch then refuses.

## Repro

```
$ ouch compress folder out.bz3.gz
before:  hint: To:   "out.bz3.tar.gz"
after:   hint: To:   "out.tar.bz3.gz"
```

Following the old hint verbatim:

```
$ ouch compress folder out.bz3.tar.gz
[ERROR] File extensions are invalid for operation
 - The archive extension '.tar' can only be placed at the start of the extension list
```

So the hint pointed at a path ouch rejects on its own terms.

## The fix

One entry added to `SUPPORTED_EXTENSIONS`.

## Verification

Two tests. One pins the suggestion for `linux.bz3` and `linux.bz3.gz`. The other walks every extension in `PRETTY_SUPPORTED_EXTENSIONS`, skips the archive-first ones, and asserts the rest are in `SUPPORTED_EXTENSIONS`, so a future addition cannot go missing the same way. Removing `bz3` again fails both, the second with the name of the offending extension.

Output above is from binaries built before and after, not from the unit tests.

Full suite passes. `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean. I built with `bzip3` off, since `libbzip3-sys` does not compile here (missing `stddef.h`); that only affects whether the resulting archive can be written, not the extension bookkeeping this changes.

`tbz2` and `tbz3` are parsable but absent from `SUPPORTED_ALIASES`. They are archive-first, so the suggestion path never consults them, and I left them alone to keep this to one concern.
