### PR TITLE
Add --show-size flag to `ouch list` (#1005)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ ouch list archive.zip
 
 # Example with tree formatting
 ouch list source-code.zip --tree
+
+# Show the (uncompressed) size of each file
+ouch list archive.zip --show-size
 ```
 
 Output:

--- a/src/archive/rar.rs
+++ b/src/archive/rar.rs
@@ -96,6 +96,7 @@ pub fn list_archive(
     Ok(archive.open_for_listing()?.map(|item| {
         let item = item?;
         let is_dir = item.is_directory();
+        let size = Some(item.unpacked_size);
         let path = item.filename;
 
         Ok(FileInArchive {
@@ -105,6 +106,7 @@ pub fn list_archive(
             } else {
                 ListFileType::File
             },
+            size,
         })
     }))
 }

--- a/src/archive/sevenz.rs
+++ b/src/archive/sevenz.rs
@@ -108,6 +108,7 @@ where
             } else {
                 ListFileType::File
             },
+            size: Some(entry.size()),
         }));
         Ok(true)
     };

--- a/src/archive/tar.rs
+++ b/src/archive/tar.rs
@@ -117,8 +117,9 @@ pub fn list_archive(mut archive: tar::Archive<impl Read>) -> Result<impl Iterato
     let entries = archive.entries()?.map(|file| {
         let file = file?;
         let path = file.path()?.into_owned();
+        let size = file.header().size().ok();
         let file_type = get_file_type(file.header(), &file)?;
-        Ok(FileInArchive { path, file_type })
+        Ok(FileInArchive { path, file_type, size })
     });
 
     Ok(entries.collect::<Vec<_>>().into_iter())

--- a/src/archive/zip.rs
+++ b/src/archive/zip.rs
@@ -152,6 +152,7 @@ where
         };
 
         let path = file.enclosed_name().unwrap_or_else(|| file.mangled_name()).to_owned();
+        let size = Some(file.size());
 
         let file_type = if file.is_dir() {
             ListFileType::Directory
@@ -170,7 +171,7 @@ where
             ListFileType::File
         };
 
-        Ok(FileInArchive { path, file_type })
+        Ok(FileInArchive { path, file_type, size })
     })
 }
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -120,6 +120,10 @@ pub enum Subcommand {
         /// Show archive contents as a tree
         #[arg(short, long)]
         tree: bool,
+
+        /// Show the (uncompressed) size of each file
+        #[arg(long)]
+        show_size: bool,
     },
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -355,7 +355,11 @@ pub fn run(args: CliArgs, question_policy: QuestionPolicy, file_visibility_polic
                 )
             })
         }
-        Subcommand::List { archives: files, tree } => {
+        Subcommand::List {
+            archives: files,
+            tree,
+            show_size,
+        } => {
             let mut formats = vec![];
 
             if let Some(format) = args.format {
@@ -434,6 +438,7 @@ pub fn run(args: CliArgs, question_policy: QuestionPolicy, file_visibility_polic
             let list_options = ListOptions {
                 tree,
                 quiet: args.quiet,
+                show_size,
             };
 
             for (i, ((archive_path, formats), spill)) in files

--- a/src/list.rs
+++ b/src/list.rs
@@ -10,7 +10,7 @@ use self::tree::Tree;
 use crate::{
     Result,
     accessible::is_running_in_accessible_mode,
-    utils::{NoQuotePathFmt, PathFmt},
+    utils::{BytesFmt, NoQuotePathFmt, PathFmt},
 };
 
 /// Options controlling how archive contents should be listed
@@ -21,6 +21,9 @@ pub struct ListOptions {
 
     /// Whether to suppress extra output like symlink targets (for scripting)
     pub quiet: bool,
+
+    /// Whether to show the (uncompressed) size of each file
+    pub show_size: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -39,6 +42,9 @@ pub struct FileInArchive {
 
     /// The type of file
     pub file_type: ListFileType,
+
+    /// The uncompressed size of the entry, when the format reports it
+    pub size: Option<u64>,
 }
 
 /// Actually print the files
@@ -56,14 +62,36 @@ pub fn list_files(
 
     if list_options.tree {
         let tree = files.into_iter().collect::<Result<Tree>>()?;
-        tree.print(&mut out);
+        tree.print(&mut out, list_options.show_size);
     } else {
         for file in files {
-            let FileInArchive { path, file_type } = file?;
+            let FileInArchive { path, file_type, size } = file?;
+            print_size_column(&mut out, list_options.show_size, &file_type, size);
             print_entry(&mut out, NoQuotePathFmt(&path), &file_type, list_options.quiet);
         }
     }
     Ok(())
+}
+
+/// Print the leading size column used by `--show-size`.
+///
+/// Files get their size formatted like the rest of `ouch`'s output, while
+/// directories (and entries whose size is unknown) get a blank column of the
+/// same width so everything stays aligned.
+fn print_size_column(out: &mut impl Write, show_size: bool, file_type: &ListFileType, size: Option<u64>) {
+    if !show_size {
+        return;
+    }
+
+    match (file_type, size) {
+        (ListFileType::File | ListFileType::Symlink { .. } | ListFileType::Hardlink { .. }, Some(size)) => {
+            let _ = write!(out, "{}  ", BytesFmt(size));
+        }
+        _ => {
+            // `BytesFmt` renders as 10 columns, keep the padding in sync with it.
+            let _ = write!(out, "{:>10}  ", "");
+        }
+    }
 }
 
 /// Print an entry and highlight directories, either by coloring them
@@ -176,13 +204,13 @@ mod tree {
         }
 
         /// Print the file tree using Unicode line characters
-        pub fn print(&self, out: &mut impl Write) {
+        pub fn print(&self, out: &mut impl Write, show_size: bool) {
             for (i, (name, subtree)) in self.children.iter().enumerate() {
-                subtree.print_(out, name, "", i == self.children.len() - 1);
+                subtree.print_(out, name, "", i == self.children.len() - 1, show_size);
             }
         }
         /// Print the tree by traversing it recursively
-        fn print_(&self, out: &mut impl Write, name: &OsStr, prefix: &str, last: bool) {
+        fn print_(&self, out: &mut impl Write, name: &OsStr, prefix: &str, last: bool, show_size: bool) {
             // If there are no further elements in the parent directory, add
             // "└── " to the prefix, otherwise add "├── "
             let final_part = match last {
@@ -190,12 +218,15 @@ mod tree {
                 false => draw::FINAL_BRANCH,
             };
 
-            let _ = write!(out, "{prefix}{final_part}");
             let file_type = match &self.file {
                 Some(FileInArchive { file_type, .. }) => file_type.clone(),
                 // If we don't have a file entry but have children, it's an implicit directory
                 None => ListFileType::Directory,
             };
+            // The size column, if any, comes before the tree branches so entries stay aligned.
+            let size = self.file.as_ref().and_then(|file| file.size);
+            super::print_size_column(out, show_size, &file_type, size);
+            let _ = write!(out, "{prefix}{final_part}");
             super::print_entry(
                 out,
                 super::NoQuotePathFmt(name.as_ref()),
@@ -212,7 +243,7 @@ mod tree {
             });
             // Recursively print all children
             for (i, (name, subtree)) in self.children.iter().enumerate() {
-                subtree.print_(out, name, &prefix, i == self.children.len() - 1);
+                subtree.print_(out, name, &prefix, i == self.children.len() - 1, show_size);
             }
         }
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1067,6 +1067,41 @@ fn sevenz_list_should_not_failed() {
     assert!(res.get_output().stdout.find(b"README.md").is_some());
 }
 
+#[test]
+fn list_show_size_displays_uncompressed_sizes() {
+    let (_tempdir, root_path) = testdir().unwrap();
+    let src_files_path = root_path.join("src_files");
+    fs::create_dir_all(&src_files_path).unwrap();
+
+    let file_path = src_files_path.join("hello.txt");
+    fs::write(&file_path, "hello world").unwrap(); // 11 bytes
+
+    let archive = root_path.join("archive.tar");
+    crate::utils::cargo_bin()
+        .arg("compress")
+        .arg("--yes")
+        .arg(&file_path)
+        .arg(&archive)
+        .assert()
+        .success();
+
+    // With `--show-size`, the pretty-printed size is shown alongside the entry.
+    let with_flag = crate::utils::cargo_bin()
+        .args(["list", "--show-size"])
+        .arg(&archive)
+        .assert()
+        .success();
+    let stdout = with_flag.get_output().stdout.clone();
+    assert!(stdout.find(b"hello.txt").is_some());
+    assert!(stdout.find(b"11.00").is_some());
+
+    // Without the flag, the default output is unchanged and carries no size.
+    let without_flag = crate::utils::cargo_bin().arg("list").arg(&archive).assert().success();
+    let stdout = without_flag.get_output().stdout.clone();
+    assert!(stdout.find(b"hello.txt").is_some());
+    assert!(stdout.find(b"11.00").is_none());
+}
+
 // TODO: for supporting windows hard link easier
 // we should wait for this issue
 // https://github.com/rust-lang/rust/issues/63010


### PR DESCRIPTION
This adds the `--show-size` flag to `ouch list` that was asked for in #1005, so you can see how big each entry is without extracting anything.

The sizes come straight from the archive metadata (tar/zip/7z/rar all report the uncompressed size per entry), so the plain `ouch list` output is byte-for-byte the same as before and you only get the extra column when you pass the flag. Files show a right-aligned size using the same `BytesFmt` the rest of ouch uses; directories get a blank, aligned column so things line up. It works in `--tree` mode too, with the size column sitting to the left of the branches.

```
$ ouch list proj.tar.gz --show-size
Archive: "proj.tar.gz"
            proj/
 12.00   B  proj/README.md
            proj/src/
  2.00   B  proj/src/tiny.txt
  3.00 kiB  proj/src/big.bin
```

Added an integration test covering both the flag and the unchanged default output.