### PR TITLE
Add --depth option to the list command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,11 @@ Categories Used:
 
 **Bullet points in chronological order by PR**
 
-## [Unreleased](https://github.com/ouch-org/ouch/compare/0.8.1...HEAD)
+# For any versions higher than 0.8.1
 
-### New Features
+This changelog shouldn't be used anymore.
 
-- Add `--depth` to `list` to only show entries up to a given number of levels (https://github.com/ouch-org/ouch/pull/1056).
-
-### Tweaks
-
-- Releases: sign assets with cosign instead of GitHub artifact attestations
+This file will be removed soon.
 
 ## [0.8.1](https://github.com/ouch-org/ouch/compare/0.8.0...0.8.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Categories Used:
 
 ## [Unreleased](https://github.com/ouch-org/ouch/compare/0.8.1...HEAD)
 
+### New Features
+
+- Add `--depth` to `list` to only show entries up to a given number of levels (https://github.com/ouch-org/ouch/pull/1056).
+
 ### Tweaks
 
 - Releases: sign assets with cosign instead of GitHub artifact attestations

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -120,6 +120,10 @@ pub enum Subcommand {
         /// Show archive contents as a tree
         #[arg(short, long)]
         tree: bool,
+
+        /// Only list entries up to this many levels deep
+        #[arg(long)]
+        depth: Option<u32>,
     },
 }
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -121,7 +121,7 @@ pub enum Subcommand {
         #[arg(short, long)]
         tree: bool,
 
-        /// Only list entries up to this many levels deep
+        /// Only list entries up to this recursion limit
         #[arg(long)]
         depth: Option<u32>,
     },

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -355,7 +355,11 @@ pub fn run(args: CliArgs, question_policy: QuestionPolicy, file_visibility_polic
                 )
             })
         }
-        Subcommand::List { archives: files, tree } => {
+        Subcommand::List {
+            archives: files,
+            tree,
+            depth,
+        } => {
             let mut formats = vec![];
 
             if let Some(format) = args.format {
@@ -434,6 +438,7 @@ pub fn run(args: CliArgs, question_policy: QuestionPolicy, file_visibility_polic
             let list_options = ListOptions {
                 tree,
                 quiet: args.quiet,
+                depth,
             };
 
             for (i, ((archive_path, formats), spill)) in files

--- a/src/list.rs
+++ b/src/list.rs
@@ -21,6 +21,9 @@ pub struct ListOptions {
 
     /// Whether to suppress extra output like symlink targets (for scripting)
     pub quiet: bool,
+
+    /// Only list entries up to this many levels deep, or all levels if `None`
+    pub depth: Option<u32>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -56,10 +59,15 @@ pub fn list_files(
 
     if list_options.tree {
         let tree = files.into_iter().collect::<Result<Tree>>()?;
-        tree.print(&mut out);
+        tree.print(&mut out, list_options.depth);
     } else {
         for file in files {
             let FileInArchive { path, file_type } = file?;
+            if let Some(depth) = list_options.depth
+                && path.components().count() as u32 > depth
+            {
+                continue;
+            }
             print_entry(&mut out, NoQuotePathFmt(&path), &file_type, list_options.quiet);
         }
     }
@@ -176,13 +184,24 @@ mod tree {
         }
 
         /// Print the file tree using Unicode line characters
-        pub fn print(&self, out: &mut impl Write) {
+        ///
+        /// `max_depth` limits how many levels are shown, counting the root's
+        /// children as level 1. `None` prints every level.
+        pub fn print(&self, out: &mut impl Write, max_depth: Option<u32>) {
             for (i, (name, subtree)) in self.children.iter().enumerate() {
-                subtree.print_(out, name, "", i == self.children.len() - 1);
+                subtree.print_(out, name, "", i == self.children.len() - 1, 1, max_depth);
             }
         }
         /// Print the tree by traversing it recursively
-        fn print_(&self, out: &mut impl Write, name: &OsStr, prefix: &str, last: bool) {
+        fn print_(
+            &self,
+            out: &mut impl Write,
+            name: &OsStr,
+            prefix: &str,
+            last: bool,
+            depth: u32,
+            max_depth: Option<u32>,
+        ) {
             // If there are no further elements in the parent directory, add
             // "└── " to the prefix, otherwise add "├── "
             let final_part = match last {
@@ -203,6 +222,11 @@ mod tree {
                 false, // Always show targets in tree view, regardless of --quiet flag
             );
 
+            // Stop before descending past the requested depth
+            if max_depth.is_some_and(|max| depth >= max) {
+                return;
+            }
+
             // Construct prefix for children, adding either a line if this isn't
             // the last entry in the parent dir or empty space if it is.
             let mut prefix = prefix.to_owned();
@@ -212,7 +236,7 @@ mod tree {
             });
             // Recursively print all children
             for (i, (name, subtree)) in self.children.iter().enumerate() {
-                subtree.print_(out, name, &prefix, i == self.children.len() - 1);
+                subtree.print_(out, name, &prefix, i == self.children.len() - 1, depth + 1, max_depth);
             }
         }
     }

--- a/src/list.rs
+++ b/src/list.rs
@@ -22,7 +22,7 @@ pub struct ListOptions {
     /// Whether to suppress extra output like symlink targets (for scripting)
     pub quiet: bool,
 
-    /// Only list entries up to this many levels deep, or all levels if `None`
+    /// Only list entries up to this recursion limit, `None` means no limit
     pub depth: Option<u32>,
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1067,6 +1067,41 @@ fn sevenz_list_should_not_failed() {
     assert!(res.get_output().stdout.find(b"README.md").is_some());
 }
 
+#[test]
+fn list_depth_limits_shown_entries() {
+    let (_tempdir, root_path) = testdir().unwrap();
+    let src = root_path.join("listdir");
+    fs::create_dir_all(src.join("sub")).unwrap();
+    fs::write(src.join("top.txt"), "contents").unwrap();
+    fs::write(src.join("sub").join("deep.txt"), "contents").unwrap();
+
+    let archive = root_path.join("archive.tar.gz");
+    crate::utils::cargo_bin()
+        .args(["compress", src.to_str().unwrap(), archive.to_str().unwrap(), "--yes"])
+        .assert()
+        .success();
+
+    // Without a limit the nested file shows up.
+    let full = crate::utils::cargo_bin()
+        .args(["list", archive.to_str().unwrap(), "--yes"])
+        .assert()
+        .success();
+    assert!(full.get_output().stdout.find(b"deep.txt").is_some());
+
+    // `--depth 1` only keeps the top-level directory.
+    for extra in [&[][..], &["--tree"]] {
+        let limited = crate::utils::cargo_bin()
+            .args(["list", archive.to_str().unwrap(), "--depth", "1", "--yes"])
+            .args(extra)
+            .assert()
+            .success();
+        let stdout = limited.get_output().stdout.clone();
+        assert!(stdout.find(b"listdir").is_some());
+        assert!(stdout.find(b"top.txt").is_none());
+        assert!(stdout.find(b"deep.txt").is_none());
+    }
+}
+
 // TODO: for supporting windows hard link easier
 // we should wait for this issue
 // https://github.com/rust-lang/rust/issues/63010


### PR DESCRIPTION
Closes #638.

Adds a `--depth N` flag to `ouch list` that only shows entries down to N levels, like the issue asked for. Works the same for the flat listing and for `--tree`, top-level entries count as depth 1.

```
$ ouch list src.tar.gz --tree --depth 2
Archive: "src.tar.gz"
└── src/
   ├── top.txt
   └── a/
```

Went with a single `--depth` since that seemed to be the preference in the issue, no `--min-depth`/`--max-depth`. Default behavior is unchanged when the flag isn't passed.