### PR TITLE
fix(completions): clarify compress positional arguments

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -18,6 +18,8 @@ use clap_complete::{Shell, generate_to};
 use clap_complete_nushell::Nushell;
 
 include!("src/cli/args.rs");
+#[path = "src/cli/completion.rs"]
+mod completion;
 
 fn main() {
     println!("cargo:rerun-if-env-changed=OUCH_ARTIFACTS_FOLDER");
@@ -29,6 +31,7 @@ fn main() {
 
         clap_mangen::generate_to(cmd.clone(), out).unwrap();
 
+        let cmd = &mut completion::with_combined_compress_positionals(CliArgs::command());
         for shell in Shell::value_variants() {
             generate_to(*shell, cmd, "ouch", out).unwrap();
         }

--- a/src/cli/completion.rs
+++ b/src/cli/completion.rs
@@ -1,0 +1,64 @@
+use clap::Command;
+
+const COMPRESSION_POSITIONAL_HELP: &str = "Input files; or output archive with compression format when placed last";
+
+pub fn with_combined_compress_positionals(mut command: Command) -> Command {
+    let compress = command
+        .find_subcommand_mut("compress")
+        .expect("compress subcommand should exist");
+
+    *compress = std::mem::take(compress).mut_args(|argument| match argument.get_id().as_str() {
+        "files" | "output" => argument.help(COMPRESSION_POSITIONAL_HELP),
+        _ => argument,
+    });
+
+    command
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::CommandFactory;
+
+    use super::*;
+    use crate::cli::CliArgs;
+
+    #[test]
+    fn keeps_standard_compress_positional_descriptions() {
+        let command = CliArgs::command();
+        let compress = command
+            .find_subcommand("compress")
+            .expect("compress subcommand should exist");
+        let descriptions = compress
+            .get_arguments()
+            .filter(|argument| matches!(argument.get_id().as_str(), "files" | "output"))
+            .map(|argument| argument.get_help().map(ToString::to_string))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            descriptions,
+            [
+                Some("Files to be compressed".to_owned()),
+                Some("The resulting file. Its extensions can be used to specify the compression formats".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn combines_compress_positional_descriptions() {
+        let command = with_combined_compress_positionals(CliArgs::command());
+        let compress = command
+            .find_subcommand("compress")
+            .expect("compress subcommand should exist");
+
+        for id in ["files", "output"] {
+            let argument = compress
+                .get_arguments()
+                .find(|argument| argument.get_id() == id)
+                .expect("compress positional argument should exist");
+            assert_eq!(
+                argument.get_help().map(ToString::to_string).as_deref(),
+                Some(COMPRESSION_POSITIONAL_HELP)
+            );
+        }
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,8 @@
 //! CLI related functions, uses the clap argparsing definitions from `args.rs`.
 
 mod args;
+#[cfg(test)]
+mod completion;
 
 use std::path::{Path, PathBuf, absolute};
 


### PR DESCRIPTION
Generated shell completions describe `<FILES>...` and `<OUTPUT>` independently, which can make their positional order look reversed while the command line is incomplete.

Use a shared description for both generated completion entries. `--help` and man-page descriptions remain unchanged.

Fixes #979

Tested with:
- `cargo test`
- `cargo clippy -- -D warnings`
- generated Zsh and Nushell completion artifacts