### PR TITLE
fix: support Zstandard (method 93) entries in zip archives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,6 +2095,7 @@ dependencies = [
  "time",
  "typed-path",
  "zeroize",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ unrar = { package = "unrar-ng", version = "0.7.6", optional = true }
 zip = { version = "8.6.0", default-features = false, features = [
     "time",
     "aes-crypto",
+    "zstd",
 ] }
 zstd = { version = "0.13.3", default-features = false, features = ["zstdmt"] }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1782,6 +1782,39 @@ fn zip_special_permission_bits_are_stripped() {
     }
 }
 
+/// Zip entries compressed with Zstandard (method 93) must list and decompress (issue #1062).
+#[test]
+fn zip_with_zstd_entries() {
+    let (_tempdir, test_dir) = testdir().unwrap();
+    let zstd_zip = test_dir.join("zstd.zip");
+
+    {
+        use zip::{CompressionMethod, write::SimpleFileOptions};
+        let file = std::fs::File::create(&zstd_zip).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        let options = SimpleFileOptions::default().compression_method(CompressionMethod::Zstd);
+        zip.start_file("test_file.txt", options).unwrap();
+        zip.write_all(b"zstd in zip").unwrap();
+        zip.finish().unwrap();
+    }
+
+    crate::utils::cargo_bin().arg("list").arg(&zstd_zip).assert().success();
+
+    let out_dir = test_dir.join("out");
+    crate::utils::cargo_bin()
+        .arg("d")
+        .arg(&zstd_zip)
+        .arg("-d")
+        .arg(&out_dir)
+        .assert()
+        .success();
+
+    assert_eq!(
+        "zstd in zip",
+        fs::read_to_string(out_dir.join("test_file.txt")).unwrap()
+    );
+}
+
 // Default mode decompression without --dir or --here is not tested elsewhere
 // These lock in the layout where output goes into a new directory named after the archive
 


### PR DESCRIPTION
Fixes #1062.

`ouch list` and `ouch decompress` failed on zip archives whose entries use Zstandard compression (method 93) with `compression method not supported: 93`, because the `zip` crate was built without its `zstd` feature.

This enables the feature — it resolves to the same `zstd` 0.13.3 already in the dependency tree, so the lockfile change is a single line — and adds a regression test that lists and decompresses a zip with a Zstd-compressed entry. Without the fix the test fails to compile, since `CompressionMethod::Zstd` is gated behind that feature.

Tested with `cargo test` (all suites pass) and `cargo fmt --check`.